### PR TITLE
Updating Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install `Period` using Composer.
 composer require league/period
 ```
 
-This will edit (or create) your `composer.json` file and automatically choose the most recenve version, foe example: `~1.0`
+This will edit (or create) your `composer.json` file and automatically choose the most recent version, for example: `~1.0`
 
 #### Going Solo
 


### PR DESCRIPTION
Added the recommended way of adding composer requirements to your projects.
The new tooling in composer can now choose the proper version and bind it correctly by using "~" and not `*`  ranges.
Ranges with `*` are more costly and resource heavy for composer and should be avoided.
