### PR TITLE
Period now uses DateTimeImmutable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ php:
   - hhvm
 
 matrix:
-allow_failures:
-  - php: hhvm
+  allow_failures:
+    - php: hhvm
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: php
 
 php:
+  - 5.5
   - 5.6
   - 7.0
   - hhvm
-
-matrix:
-  allow_failures:
-    - php: hhvm
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ php:
   - 7.0
   - hhvm
 
+matrix:
+  allow_failures:
+    - php: 7.0
+
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/thephpleague/period/issues"
     },
     "require": {
-        "php" : ">=5.6.0"
+        "php" : ">=5.5.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*"

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "description" : "A time range immutable value object",
     "keywords": ["date", "time", "datetime", "range", "interval", "dateinterval", "dateperiod"],
     "license": "MIT",
+    "homepage": "http://period.thephpleague.com",
     "authors": [
         {
             "name" : "Ignace Nyamagana Butera",
@@ -37,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.5-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/thephpleague/period/issues"
     },
     "require": {
-        "php" : ">=5.4.0"
+        "php" : ">=5.6.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*"

--- a/src/Period.php
+++ b/src/Period.php
@@ -20,6 +20,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
+use JsonSerializable;
 use LogicException;
 use OutOfRangeException;
 use RuntimeException;
@@ -27,7 +28,7 @@ use RuntimeException;
 /**
  * A immutable value object class to manipulate Time Range.
  */
-final class Period
+final class Period implements JsonSerializable
 {
     /**
      * Date Format to create ISO8601 Interval format
@@ -274,6 +275,19 @@ final class Period
 
         return $this->startDate->setTimeZone($utc)->format(self::ISO8601)
             .'/'.$this->endDate->setTimeZone($utc)->format(self::ISO8601);
+    }
+
+    /**
+     * implement JsonSerializable interface
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'startDate' => $this->startDate,
+            'endDate' => $this->endDate,
+        ];
     }
 
     /**

--- a/src/Period.php
+++ b/src/Period.php
@@ -58,8 +58,8 @@ final class Period
      */
     public function __construct($startDate, $endDate)
     {
-        $this->startDate = self::validateDateTime($startDate);
-        $this->endDate   = self::validateDateTime($endDate);
+        $this->startDate = self::validateDate($startDate);
+        $this->endDate   = self::validateDate($endDate);
         if ($this->startDate > $this->endDate) {
             throw new LogicException('the ending endpoint must be greater or equal to the starting endpoint');
         }
@@ -74,7 +74,7 @@ final class Period
      *
      * @return \DateTimeImmutable
      */
-    private static function validateDateTime($datetime)
+    private static function validateDate($datetime)
     {
         if ($datetime instanceof DateTime) {
             return DateTimeImmutable::createFromMutable($datetime);
@@ -231,7 +231,7 @@ final class Period
             return $this->startDate >= $index->endDate;
         }
 
-        return $this->startDate > self::validateDateTime($index);
+        return $this->startDate > self::validateDate($index);
     }
 
     /**
@@ -247,7 +247,7 @@ final class Period
             return $this->endDate <= $index->startDate;
         }
 
-        return $this->endDate <= self::validateDateTime($index);
+        return $this->endDate <= self::validateDate($index);
     }
 
     /**
@@ -264,7 +264,7 @@ final class Period
             return $this->contains($index->startDate) && $this->contains($index->endDate);
         }
 
-        $datetime = self::validateDateTime($index);
+        $datetime = self::validateDate($index);
 
         return $datetime >= $this->startDate && $datetime < $this->endDate;
     }
@@ -340,9 +340,9 @@ final class Period
      */
     public static function createFromDuration($startDate, $interval)
     {
-        $startDate = self::validateDateTime($startDate);
+        $date = self::validateDate($startDate);
 
-        return new self($startDate, $startDate->add(self::validateDateInterval($interval)));
+        return new self($date, $date->add(self::validateDateInterval($interval)));
     }
 
     /**
@@ -358,9 +358,9 @@ final class Period
      */
     public static function createFromDurationBeforeEnd($endDate, $interval)
     {
-        $endDate = self::validateDateTime($endDate);
+        $date = self::validateDate($endDate);
 
-        return new self($endDate->sub(self::validateDateInterval($interval)), $endDate);
+        return new self($date->sub(self::validateDateInterval($interval)), $date);
     }
 
     /**
@@ -490,7 +490,7 @@ final class Period
      */
     public function startingOn($startDate)
     {
-        return new self(self::validateDateTime($startDate), $this->endDate);
+        return new self(self::validateDate($startDate), $this->endDate);
     }
 
     /**
@@ -504,7 +504,7 @@ final class Period
      */
     public function endingOn($endDate)
     {
-        return new self($this->startDate, self::validateDateTime($endDate));
+        return new self($this->startDate, self::validateDate($endDate));
     }
 
     /**
@@ -519,7 +519,7 @@ final class Period
      */
     public function withDuration($interval)
     {
-        return new self($this->startDate, $this->startDate->add($interval));
+        return new self($this->startDate, $this->startDate->add(self::validateDateInterval($interval)));
     }
 
     /**
@@ -574,7 +574,7 @@ final class Period
             $interval = $this->getDateInterval();
         }
 
-        return new self($this->endDate, $this->end->add($interval));
+        return new self($this->endDate, $this->endDate->add(self::validateDateInterval($interval)));
     }
 
     /**
@@ -595,7 +595,7 @@ final class Period
             $interval = $this->getDateInterval();
         }
 
-        return new self($this->startDate->sub($interval), $this->startDate);
+        return new self($this->startDate->sub(self::validateDateInterval($interval)), $this->startDate);
     }
 
     /**
@@ -726,8 +726,8 @@ final class Period
      */
     private static function createFromEndpoints($endPoint1, $endPoint2)
     {
-        $startDate = self::validateDateTime($endPoint1);
-        $endDate   = self::validateDateTime($endPoint2);
+        $startDate = self::validateDate($endPoint1);
+        $endDate   = self::validateDate($endPoint2);
         if ($startDate > $endDate) {
             return new self($endDate, $startDate);
         }

--- a/src/Period.php
+++ b/src/Period.php
@@ -630,6 +630,7 @@ final class Period
     public function split($interval)
     {
         $res = [];
+        $interval = self::validateDateInterval($interval);
         foreach ($this->getDatePeriod($interval) as $startDate) {
             $endDate = $startDate->add($interval);
             if ($endDate > $this->endDate) {

--- a/src/Period.php
+++ b/src/Period.php
@@ -18,7 +18,6 @@ use DateInterval;
 use DatePeriod;
 use DateTime;
 use DateTimeImmutable;
-use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
 use LogicException;
@@ -59,13 +58,11 @@ final class Period
      */
     public function __construct($startDate, $endDate)
     {
-        $startDate = self::validateDateTime($startDate);
-        $endDate   = self::validateDateTime($endDate);
-        if ($startDate > $endDate) {
+        $this->startDate = self::validateDateTime($startDate);
+        $this->endDate   = self::validateDateTime($endDate);
+        if ($this->startDate > $this->endDate) {
             throw new LogicException('the ending endpoint must be greater or equal to the starting endpoint');
         }
-        $this->startDate = $startDate;
-        $this->endDate   = $endDate;
     }
 
     /**
@@ -81,7 +78,7 @@ final class Period
     {
         if ($datetime instanceof DateTime) {
             return DateTimeImmutable::createFromMutable($datetime);
-        } elseif ($datetime instanceof DateTimeInterface) {
+        } elseif ($datetime instanceof DateTimeImmutable) {
             return $datetime;
         }
 
@@ -224,7 +221,7 @@ final class Period
     /**
      * Tells whether a Period is entirely after the specified index
      *
-     * @param \League\Period\Period|\DateTimeInterface|\DateTime $index
+     * @param \League\Period\Period|\DateTimeInterface $index
      *
      * @return bool
      */
@@ -240,7 +237,7 @@ final class Period
     /**
      * Tells whether a Period is entirely before the specified index
      *
-     * @param \League\Period\Period|\DateTimeInterface|\DateTime $index
+     * @param \League\Period\Period|\DateTimeInterface $index
      *
      * @return bool
      */
@@ -522,7 +519,7 @@ final class Period
      */
     public function withDuration($interval)
     {
-        return self::createFromDuration($this->startDate, $interval);
+        return new self($this->startDate, $this->startDate->add($interval));
     }
 
     /**
@@ -577,7 +574,7 @@ final class Period
             $interval = $this->getDateInterval();
         }
 
-        return self::createFromDuration($this->endDate, $interval);
+        return new self($this->endDate, $this->end->add($interval));
     }
 
     /**
@@ -598,7 +595,7 @@ final class Period
             $interval = $this->getDateInterval();
         }
 
-        return self::createFromDurationBeforeEnd($this->startDate, $interval);
+        return new self($this->startDate->sub($interval), $this->startDate);
     }
 
     /**
@@ -722,8 +719,8 @@ final class Period
      * The endpoints will be used as to allow the creation of
      * a Period object
      *
-     * @param string|\DateTimeInterface|\DateTime $endPoint1 endpoint
-     * @param string|\DateTimeInterface|\DateTime $endPoint2 endpoint
+     * @param string|\DateTimeInterface $endPoint1 endpoint
+     * @param string|\DateTimeInterface $endPoint2 endpoint
      *
      * @return \League\Period\Period
      */

--- a/src/Period.php
+++ b/src/Period.php
@@ -632,7 +632,7 @@ final class Period
         $res = [];
         foreach ($this->getDatePeriod($interval) as $startDate) {
             $endDate = $startDate->add($interval);
-            if ($endDate > $this->endDate)) {
+            if ($endDate > $this->endDate) {
                 $endDate = $this->endDate;
             }
             $res[] = new self($startDate, $endDate);

--- a/src/Period.php
+++ b/src/Period.php
@@ -295,10 +295,27 @@ final class Period implements JsonSerializable
      */
     public function jsonSerialize()
     {
+        if (! defined('HHVM_VERSION')) {
+            return [
+                'startDate' => $this->startDate,
+                'endDate' => $this->endDate,
+            ];
+        }
+
+        $format = 'Y-m-d H:i:s.u';
         return [
-            'startDate' => $this->startDate,
-            'endDate' => $this->endDate,
+            'startDate' => DateTime::createFromFormat(
+                $format,
+                $this->startDate->format($format),
+                $this->startDate->getTimeZone()
+            ),
+            'endDate' => DateTime::createFromFormat(
+                $format,
+                $this->endDate->format($format),
+                $this->endDate->getTimeZone()
+            ),
         ];
+
     }
 
     /**

--- a/src/Period.php
+++ b/src/Period.php
@@ -605,17 +605,18 @@ final class Period
      */
     public function merge(Period ...$periods)
     {
-        $res = clone $this;
-        array_walk($periods, function (Period $period) use (&$res) {
-            if ($res->startDate > $period->startDate) {
-                $res = $res->startingOn($period->startDate);
+        $initiate = clone $this;
+        
+        return array_reduce($periods, function (Period $carry, Period $period) {
+            if ($carry->startDate > $period->startDate) {
+                $carry = $carry->startingOn($period->startDate);
             }
-            if ($res->endDate < $period->endDate) {
-                $res = $res->endingOn($period->endDate);
+            if ($carry->endDate < $period->endDate) {
+                $carry = $carry->endingOn($period->endDate);
             }
-        });
 
-        return $res;
+            return $carry;
+        }, $initiate);
     }
 
     /**

--- a/src/Period.php
+++ b/src/Period.php
@@ -631,7 +631,7 @@ final class Period
     {
         $res = [];
         foreach ($this->getDatePeriod($interval) as $startDate) {
-            $endDate = $startDate->add($interval));
+            $endDate = $startDate->add($interval);
             if ($endDate > $this->endDate)) {
                 $endDate = $this->endDate;
             }

--- a/src/Period.php
+++ b/src/Period.php
@@ -5,7 +5,7 @@
  *
  * @license http://opensource.org/licenses/MIT
  * @link https://github.com/thephpleague/period/
- * @version 2.5.0
+ * @version 3.0.0
  * @package League.Period
  *
  * For the full copyright and license information, please view the LICENSE
@@ -30,29 +30,29 @@ use RuntimeException;
 final class Period
 {
     /**
-     * DateTime Format to create ISO8601 Interval format
+     * Date Format to create ISO8601 Interval format
      */
     const ISO8601 = 'Y-m-d\TH:i:s\Z';
 
     /**
      * Period starting included datepoint.
      *
-     * @var \DateTimeInterface|\DateTime
+     * @var \DateTimeImmutable
      */
     private $startDate;
 
     /**
      * Period ending excluded datepoint.
      *
-     * @var \DateTimeInterface|\DateTime
+     * @var \DateTimeImmutable
      */
     private $endDate;
 
     /**
      * Create a new instance.
      *
-     * @param string|\DateTimeInterface|\DateTime $startDate starting datepoint
-     * @param string|\DateTimeInterface|\DateTime $endDate   ending datepoint
+     * @param string|\DateTimeInterface $startDate starting datepoint
+     * @param string|\DateTimeInterface $endDate   ending datepoint
      *
      * @throws \LogicException If $startDate is greater than $endDate
      */
@@ -61,16 +61,16 @@ final class Period
         $this->startDate = self::validateDate($startDate);
         $this->endDate   = self::validateDate($endDate);
         if ($this->startDate > $this->endDate) {
-            throw new LogicException('the ending endpoint must be greater or equal to the starting endpoint');
+            throw new LogicException('the ending datepoint must be greater or equal to the starting datepoint');
         }
     }
 
     /**
-     * Validate a DateTime.
+     * Validate a DateTimeImmutable object.
      *
-     * @param string|\DateTimeInterface|\DateTime $datetime
+     * @param string|\DateTimeInterface $datetime
      *
-     * @throws \RuntimeException If The Data can not be converted into a proper DateTime object
+     * @throws \RuntimeException If The Data can not be converted into a proper DateTimeImmutable object
      *
      * @return \DateTimeImmutable
      */
@@ -109,7 +109,7 @@ final class Period
     }
 
     /**
-     * Returns the ending endpoint.
+     * Returns the ending datepoint.
      *
      * @return \DateTimeImmutable
      */
@@ -178,7 +178,7 @@ final class Period
     }
 
     /**
-     * Tells whether two Period share the same endpoints.
+     * Tells whether two Period share the same datepoints.
      *
      * @param \League\Period\Period $period
      *
@@ -345,7 +345,7 @@ final class Period
     }
 
     /**
-     * Create a Period object from a ending endpoint and an interval.
+     * Create a Period object from a ending datepoint and an interval.
      *
      * @param string|\DateTimeInterface $endDate  end datepoint
      * @param \DateInterval|int|string  $interval The duration. If an int is passed, it is
@@ -428,9 +428,9 @@ final class Period
      */
     public static function createFromMonth($year, $month)
     {
-        $month = self::validateRange($month, 1, 12);
+        $month = sprintf('%02s', self::validateRange($month, 1, 12));
 
-        return self::createFromDuration(self::validateYear($year).'-'.sprintf('%02s', $month).'-01', '1 MONTH');
+        return self::createFromDuration(self::validateYear($year).'-'.$month.'-01', '1 MONTH');
     }
 
     /**
@@ -443,9 +443,9 @@ final class Period
      */
     public static function createFromQuarter($year, $quarter)
     {
-        $month = ((self::validateRange($quarter, 1, 4) - 1) * 3) + 1;
+        $month = sprintf('%02s', ((self::validateRange($quarter, 1, 4) - 1) * 3) + 1);
 
-        return self::createFromDuration(self::validateYear($year).'-'.sprintf('%02s', $month).'-01', '3 MONTHS');
+        return self::createFromDuration(self::validateYear($year).'-'.$month.'-01', '3 MONTHS');
     }
 
     /**
@@ -458,9 +458,9 @@ final class Period
      */
     public static function createFromSemester($year, $semester)
     {
-        $month = ((self::validateRange($semester, 1, 2) - 1) * 6) + 1;
+        $month = sprintf('%02s', ((self::validateRange($semester, 1, 2) - 1) * 6) + 1);
 
-        return self::createFromDuration(self::validateYear($year).'-'.sprintf('%02s', $month).'-01', '6 MONTHS');
+        return self::createFromDuration(self::validateYear($year).'-'.$month.'-01', '6 MONTHS');
     }
 
     /**
@@ -554,7 +554,7 @@ final class Period
 
     /**
      * Returns a new Period object adjacent to the current Period
-     * and starting with its ending endpoint.
+     * and starting with its ending datepoint.
      * If no duration is provided the new Period will be created
      * using the current object duration
      *
@@ -575,7 +575,7 @@ final class Period
 
     /**
      * Returns a new Period object adjacent to the current Period
-     * and ending with its starting endpoint.
+     * and ending with its starting datepoint.
      * If no duration is provided the new Period will have the
      * same duration as the current one
      *
@@ -686,9 +686,9 @@ final class Period
      * Computes the difference between two overlapsing Period objects
      * and return an array containing the difference expressed as Period objects
      * The array will:
-     * - be empty if both objects have the same endpoints
-     * - contain one Period object if both objects share one endpoint
-     * - contain two Period objects if both objects share no endpoint
+     * - be empty if both objects have the same datepoints
+     * - contain one Period object if both objects share one datepoint
+     * - contain two Period objects if both objects share no datepoint
      *
      * @param \League\Period\Period $period
      *
@@ -703,8 +703,8 @@ final class Period
         }
 
         $res = [
-            self::createFromEndpoints($this->startDate, $period->startDate),
-            self::createFromEndpoints($this->endDate, $period->endDate),
+            self::createFromDatepoints($this->startDate, $period->startDate),
+            self::createFromDatepoints($this->endDate, $period->endDate),
         ];
 
         return array_values(array_filter($res, function (Period $period) {
@@ -713,16 +713,16 @@ final class Period
     }
 
     /**
-     * Create a new Period instance given two endpoints
-     * The endpoints will be used as to allow the creation of
+     * Create a new Period instance given two datepoints
+     * The datepoints will be used as to allow the creation of
      * a Period object
      *
-     * @param string|\DateTimeInterface $datePoint1 endpoint
-     * @param string|\DateTimeInterface $datePoint2 endpoint
+     * @param string|\DateTimeInterface $datePoint1 datepoint
+     * @param string|\DateTimeInterface $datePoint2 datepoint
      *
      * @return \League\Period\Period
      */
-    private static function createFromEndpoints($datePoint1, $datePoint2)
+    private static function createFromDatepoints($datePoint1, $datePoint2)
     {
         $startDate = self::validateDate($datePoint1);
         $endDate   = self::validateDate($datePoint2);

--- a/src/Period.php
+++ b/src/Period.php
@@ -76,10 +76,10 @@ final class Period
      */
     private static function validateDate($datetime)
     {
-        if ($datetime instanceof DateTime) {
-            return DateTimeImmutable::createFromMutable($datetime);
-        } elseif ($datetime instanceof DateTimeImmutable) {
+        if ($datetime instanceof DateTimeImmutable) {
             return $datetime;
+        } elseif ($datetime instanceof DateTime) {
+            return DateTimeImmutable::createFromMutable($datetime);
         }
 
         return new DateTimeImmutable($datetime);
@@ -95,8 +95,7 @@ final class Period
         $utc = new DateTimeZone('UTC');
 
         return $this->startDate->setTimeZone($utc)->format(self::ISO8601)
-            .'/'
-            .$this->endDate->setTimeZone($utc)->format(self::ISO8601);
+            .'/'.$this->endDate->setTimeZone($utc)->format(self::ISO8601);
     }
 
     /**
@@ -429,10 +428,9 @@ final class Period
      */
     public static function createFromMonth($year, $month)
     {
-        $year  = self::validateYear($year);
         $month = self::validateRange($month, 1, 12);
 
-        return self::createFromDuration($year.'-'.sprintf('%02s', $month).'-01', '1 MONTH');
+        return self::createFromDuration(self::validateYear($year).'-'.sprintf('%02s', $month).'-01', '1 MONTH');
     }
 
     /**
@@ -445,10 +443,9 @@ final class Period
      */
     public static function createFromQuarter($year, $quarter)
     {
-        $year  = self::validateYear($year);
         $month = ((self::validateRange($quarter, 1, 4) - 1) * 3) + 1;
 
-        return self::createFromDuration($year.'-'.sprintf('%02s', $month).'-01', '3 MONTHS');
+        return self::createFromDuration(self::validateYear($year).'-'.sprintf('%02s', $month).'-01', '3 MONTHS');
     }
 
     /**
@@ -461,10 +458,9 @@ final class Period
      */
     public static function createFromSemester($year, $semester)
     {
-        $year  = self::validateYear($year);
         $month = ((self::validateRange($semester, 1, 2) - 1) * 6) + 1;
 
-        return self::createFromDuration($year.'-'.sprintf('%02s', $month).'-01', '6 MONTHS');
+        return self::createFromDuration(self::validateYear($year).'-'.sprintf('%02s', $month).'-01', '6 MONTHS');
     }
 
     /**
@@ -635,11 +631,11 @@ final class Period
     {
         $res = [];
         foreach ($this->getDatePeriod($interval) as $startDate) {
-            $period = self::createFromDuration($startDate, $interval);
-            if ($period->contains($this->endDate)) {
-                $period = $period->endingOn($this->endDate);
+            $endDate = $startDate->add($interval));
+            if ($endDate > $this->endDate)) {
+                $endDate = $this->endDate;
             }
-            $res[] = $period;
+            $res[] = new self($startDate, $endDate);
         }
 
         return $res;
@@ -719,15 +715,15 @@ final class Period
      * The endpoints will be used as to allow the creation of
      * a Period object
      *
-     * @param string|\DateTimeInterface $endPoint1 endpoint
-     * @param string|\DateTimeInterface $endPoint2 endpoint
+     * @param string|\DateTimeInterface $datePoint1 endpoint
+     * @param string|\DateTimeInterface $datePoint2 endpoint
      *
      * @return \League\Period\Period
      */
-    private static function createFromEndpoints($endPoint1, $endPoint2)
+    private static function createFromEndpoints($datePoint1, $datePoint2)
     {
-        $startDate = self::validateDate($endPoint1);
-        $endDate   = self::validateDate($endPoint2);
+        $startDate = self::validateDate($datePoint1);
+        $endDate   = self::validateDate($datePoint2);
         if ($startDate > $endDate) {
             return new self($endDate, $startDate);
         }

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -34,16 +34,16 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     public function testJsonSerialize()
     {
         $period = Period::createFromMonth(2015, 4);
-        $res    = json_decode(json_encode($period), true);
+        $res    = json_decode(json_encode($period));
 
         $this->assertEquals(
             $period->getStartDate(),
-            new DateTimeImmutable($res['startDate']['date'], new DateTimeZone($res['startDate']['timezone']))
+            new DateTimeImmutable($res->startDate->date, new DateTimeZone($res->startDate->timezone))
         );
 
         $this->assertEquals(
             $period->getEndDate(),
-            new DateTimeImmutable($res['endDate']['date'], new DateTimeZone($res['endDate']['timezone']))
+            new DateTimeImmutable($res->endDate->date, new DateTimeZone($res->endDate->timezone))
         );
     }
 

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -28,13 +28,13 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     {
         date_default_timezone_set('Africa/Nairobi');
         $period = new Period('2014-05-01', '2014-05-08');
-        $this->assertSame('2014-04-30T21:00:00Z/2014-05-07T21:00:00Z', (string) $period);
+        $this->assertSame('2014-04-30T21:00:00.000000Z/2014-05-07T21:00:00.000000Z', (string) $period);
     }
 
     public function testJsonSerialize()
     {
         $period = Period::createFromMonth(2015, 4);
-        $res = json_decode(json_encode($period), true);
+        $res    = json_decode(json_encode($period), true);
 
         $this->assertEquals(
             $period->getStartDate(),
@@ -69,7 +69,7 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $period = Period::createFromMonth(2014, 3);
         $start  = new DateTime('2014-03-01');
         $end    = new DateTime('2014-04-01');
-        $res = $period->getDateInterval();
+        $res    = $period->getDateInterval();
         $this->assertInstanceof('DateInterval', $res);
         $this->assertEquals($start->diff($end), $res);
     }
@@ -79,7 +79,7 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $period = Period::createFromMonth(2014, 3);
         $start  = new DateTime('2014-03-01');
         $end    = new DateTime('2014-04-01');
-        $res = $period->getTimestampInterval();
+        $res    = $period->getTimestampInterval();
         $this->assertInternalType('integer', $res);
         $this->assertEquals($end->getTimestamp() - $start->getTimestamp(), $res);
     }

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -71,8 +71,11 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     public function testConstructor()
     {
         $period = new Period('2014-05-01', '2014-05-08');
-        $this->assertEquals(new DateTime('2014-05-01'), $period->getStartDate());
-        $this->assertEquals(new DateTime('2014-05-08'), $period->getEndDate());
+        $start = $period->getStartDate();
+        $this->assertEquals(new DateTime('2014-05-01'), $start);
+        $this->assertEquals(new DateTime('2014-05-08'), $start);
+        $this->assertInstanceof('DateTimeInterface', $start);
+        $this->assertInstanceof('DateTimeImmutable', $start);
     }
 
     /**
@@ -91,11 +94,11 @@ class PeriodTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorWithDateTimeInterface()
     {
-        $start = new DateTimeImmutable('2014-05-01');
-        $end = new DateTimeImmutable('2014-05-08');
+        $start  = new DateTimeImmutable('2014-05-01');
+        $end    = new DateTime('2014-05-08');
         $period = new Period($start, $end);
-        $this->assertInstanceof('DateTimeInterface', $period->getStartDate());
-        $this->assertInstanceof('DateTimeImmutable', $period->getStartDate());
+        $this->assertInstanceof('DateTimeInterface', $period->getEndDate());
+        $this->assertInstanceof('DateTimeImmutable', $period->getEndDate());
         $this->assertEquals($start, $period->getStartDate());
     }
 

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -517,6 +517,14 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $altPeriod->merge($period));
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testMergeThrowsException()
+    {
+        Period::createFromMonth(2014, 3)->merge();
+    }
+
     public function testSplit()
     {
         $period = Period::createFromDuration(new DateTime(), "1 DAY");

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -73,7 +73,7 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $period = new Period('2014-05-01', '2014-05-08');
         $start = $period->getStartDate();
         $this->assertEquals(new DateTimeImmutable('2014-05-01'), $start);
-        $this->assertEquals(new DateTimeImmutable('2014-05-08'), $start);
+        $this->assertEquals(new DateTimeImmutable('2014-05-08'), $period->getEndDate());
         $this->assertInstanceof('DateTimeInterface', $start);
         $this->assertInstanceof('DateTimeImmutable', $start);
     }
@@ -458,7 +458,7 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $expected  = new DateTime('2012-03-02');
         $period    = Period::createFromWeek(2014, 3);
         $newPeriod = $period->startingOn($expected);
-        $this->assertEquals($newPeriod->getStartDate(), $expected);
+        $this->assertTrue($newPeriod->getStartDate() == $expected);
         $this->assertEquals($period->getStartDate(), new DateTimeImmutable('2014-01-13'));
     }
 
@@ -476,7 +476,7 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $expected  = new DateTime('2015-03-02');
         $period    = Period::createFromWeek(2014, 3);
         $newPeriod = $period->endingOn($expected);
-        $this->assertEquals($newPeriod->getEndDate(), $expected);
+        $this->assertTrue($newPeriod->getEndDate() == $expected);
         $this->assertEquals($period->getEndDate(), new DateTimeImmutable('2014-01-20'));
     }
 
@@ -515,15 +515,6 @@ class PeriodTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $period->merge($altPeriod));
         $this->assertEquals($expected, $altPeriod->merge($period));
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testMergeThrowsException()
-    {
-        $period = Period::createFromMonth(2014, 3);
-        $period->merge();
     }
 
     public function testSplit()

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -31,6 +31,22 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $this->assertSame('2014-04-30T21:00:00Z/2014-05-07T21:00:00Z', (string) $period);
     }
 
+    public function testJsonSerialize()
+    {
+        $period = Period::createFromMonth(2015, 4);
+        $res = json_decode(json_encode($period), true);
+
+        $this->assertEquals(
+            $period->getStartDate(),
+            new DateTimeImmutable($res['startDate']['date'], new DateTimeZone($res['startDate']['timezone']))
+        );
+
+        $this->assertEquals(
+            $period->getEndDate(),
+            new DateTimeImmutable($res['endDate']['date'], new DateTimeZone($res['endDate']['timezone']))
+        );
+    }
+
     public function testGetDatePeriod()
     {
         $period = Period::createFromDuration(new DateTime(), "1 DAY");

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -72,8 +72,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     {
         $period = new Period('2014-05-01', '2014-05-08');
         $start = $period->getStartDate();
-        $this->assertEquals(new DateTime('2014-05-01'), $start);
-        $this->assertEquals(new DateTime('2014-05-08'), $start);
+        $this->assertEquals(new DateTimeImmutable('2014-05-01'), $start);
+        $this->assertEquals(new DateTimeImmutable('2014-05-08'), $start);
         $this->assertInstanceof('DateTimeInterface', $start);
         $this->assertInstanceof('DateTimeImmutable', $start);
     }
@@ -89,9 +89,6 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @requires PHP 5.5
-     */
     public function testConstructorWithDateTimeInterface()
     {
         $start  = new DateTimeImmutable('2014-05-01');
@@ -106,8 +103,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     {
         $start = new DateTime();
         $period = Period::createFromDuration($start, "1 DAY");
-        $this->assertEquals($period->getStartDate(), $start);
-        $this->assertEquals($period->getEndDate(), $start->add(new DateInterval('P1D')));
+        $this->assertTrue($period->getStartDate() == $start);
+        $this->assertTrue($period->getEndDate() == $start->add(new DateInterval('P1D')));
     }
 
     public function testCreateFromDurationWithString()
@@ -117,14 +114,14 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $end = clone $start;
         $end->add($ttl);
         $period = Period::createFromDuration("-1 DAY", $ttl);
-        $this->assertEquals($period->getStartDate(), $start);
-        $this->assertEquals($period->getEndDate(), $end);
+        $this->assertTrue($period->getStartDate() == $start);
+        $this->assertTrue($period->getEndDate() == $end);
     }
 
     public function testCreatFromDurationWithInteger()
     {
         $period = Period::createFromDuration('2014-01-01', 3600);
-        $this->assertEquals(new DateTime('2014-01-01 01:00:00'), $period->getEndDate());
+        $this->assertEquals(new DateTimeImmutable('2014-01-01 01:00:00'), $period->getEndDate());
     }
 
     /**
@@ -147,8 +144,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     {
         $end = new DateTime();
         $period = Period::createFromDurationBeforeEnd($end, "1 DAY");
-        $this->assertEquals($period->getEndDate(), $end);
-        $this->assertEquals($period->getStartDate(), $end->sub(new DateInterval('P1D')));
+        $this->assertTrue($period->getEndDate() == $end);
+        $this->assertTrue($period->getStartDate() == $end->sub(new DateInterval('P1D')));
     }
 
     public function testCreateFromDurationBeforeEndWithString()
@@ -158,8 +155,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $start = clone $end;
         $start->sub($ttl);
         $period = Period::createFromDurationBeforeEnd("-1 DAY", $ttl);
-        $this->assertEquals($period->getStartDate(), $start);
-        $this->assertEquals($period->getEndDate(), $end);
+        $this->assertTrue($period->getStartDate() == $start);
+        $this->assertTrue($period->getEndDate() == $end);
     }
 
     /**
@@ -173,8 +170,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     public function testCreateFromWeek()
     {
         $period = Period::createFromWeek(2014, 3);
-        $this->assertEquals($period->getStartDate(), new DateTime('2014-01-13'));
-        $this->assertEquals($period->getEndDate(), new DateTime('2014-01-20'));
+        $this->assertEquals($period->getStartDate(), new DateTimeImmutable('2014-01-13'));
+        $this->assertEquals($period->getEndDate(), new DateTimeImmutable('2014-01-20'));
     }
 
     /**
@@ -204,8 +201,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     public function testCreateFromMonth()
     {
         $period = Period::createFromMonth(2014, 3);
-        $this->assertEquals($period->getStartDate(), new DateTime('2014-03-01'));
-        $this->assertEquals($period->getEndDate(), new DateTime('2014-04-01'));
+        $this->assertEquals($period->getStartDate(), new DateTimeImmutable('2014-03-01'));
+        $this->assertEquals($period->getEndDate(), new DateTimeImmutable('2014-04-01'));
     }
 
     /**
@@ -235,8 +232,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     public function testCreateFromQuarter()
     {
         $period = Period::createFromQuarter(2014, 3);
-        $this->assertEquals($period->getStartDate(), new DateTime('2014-07-01'));
-        $this->assertEquals($period->getEndDate(), new DateTime('2014-10-01'));
+        $this->assertEquals($period->getStartDate(), new DateTimeImmutable('2014-07-01'));
+        $this->assertEquals($period->getEndDate(), new DateTimeImmutable('2014-10-01'));
     }
 
     /**
@@ -266,8 +263,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     public function testCreateFromSemester()
     {
         $period = Period::createFromSemester(2014, 2);
-        $this->assertEquals($period->getStartDate(), new DateTime('2014-07-01'));
-        $this->assertEquals($period->getEndDate(), new DateTime('2015-01-01'));
+        $this->assertEquals($period->getStartDate(), new DateTimeImmutable('2014-07-01'));
+        $this->assertEquals($period->getEndDate(), new DateTimeImmutable('2015-01-01'));
     }
 
     /**
@@ -297,8 +294,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     public function testCreateFromYear()
     {
         $period = Period::createFromYear(2014);
-        $this->assertEquals($period->getStartDate(), new DateTime('2014-01-01'));
-        $this->assertEquals($period->getEndDate(), new DateTime('2015-01-01'));
+        $this->assertEquals($period->getStartDate(), new DateTimeImmutable('2014-01-01'));
+        $this->assertEquals($period->getEndDate(), new DateTimeImmutable('2015-01-01'));
     }
 
     /**
@@ -398,7 +395,7 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     public function testOverlapsFalseWithGappingPeriod()
     {
         $orig = Period::createFromMonth(2014, 3);
-        $alt = Period::createFromMonth(2013, 4);
+        $alt  = Period::createFromMonth(2013, 4);
         $this->assertFalse($orig->overlaps($alt));
     }
 
@@ -445,8 +442,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
 
     public function testSameValueAsFalseWithSameStartingValue()
     {
-        $orig  = Period::createFromDuration('2012-01-01', '1 MONTH');
-        $alt   = Period::createFromDuration('2012-01-01', '1 WEEK');
+        $orig = Period::createFromDuration('2012-01-01', '1 MONTH');
+        $alt  = Period::createFromDuration('2012-01-01', '1 WEEK');
         $this->assertFalse($orig->sameValueAs($alt));
     }
 
@@ -462,7 +459,7 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $period    = Period::createFromWeek(2014, 3);
         $newPeriod = $period->startingOn($expected);
         $this->assertEquals($newPeriod->getStartDate(), $expected);
-        $this->assertEquals($period->getStartDate(), new DateTime('2014-01-13'));
+        $this->assertEquals($period->getStartDate(), new DateTimeImmutable('2014-01-13'));
     }
 
     /**
@@ -480,7 +477,7 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $period    = Period::createFromWeek(2014, 3);
         $newPeriod = $period->endingOn($expected);
         $this->assertEquals($newPeriod->getEndDate(), $expected);
-        $this->assertEquals($period->getEndDate(), new DateTime('2014-01-20'));
+        $this->assertEquals($period->getEndDate(), new DateTimeImmutable('2014-01-20'));
     }
 
     /**
@@ -756,8 +753,8 @@ class PeriodTest extends PHPUnit_Framework_TestCase
         $res = $alt->diff($period);
         $this->assertCount(1, $res);
         $this->assertInstanceof('League\Period\Period', $res[0]);
-        $this->assertEquals(new Datetime('2013-04-01'), $res[0]->getStartDate());
-        $this->assertEquals(new Datetime('2014-01-01'), $res[0]->getEndDate());
+        $this->assertEquals(new DateTimeImmutable('2013-04-01'), $res[0]->getStartDate());
+        $this->assertEquals(new DateTimeImmutable('2014-01-01'), $res[0]->getEndDate());
     }
 
     public function testDiffWithOverlapsPeriod()

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -98,6 +98,10 @@ class PeriodTest extends PHPUnit_Framework_TestCase
     {
         $period = Period::createFromDuration(new DateTime(), "1 DAY");
         $range  = $period->split("2 DAY");
+        //HHVM bug fix
+        if (defined('HHVM_VERSION')) {
+            $range->next();
+        }
         $this->assertEquals($period, $range->current());
     }
 


### PR DESCRIPTION
A new `Period` class
- uses `DateTimeImmutable` rather than `DateTime`;
- PHP min. version is now PHP5.5
- added `JsonSerializable` interface
- `Period::split` now returns an `Generator` 
- added hacks around bugs in HHVM