### PR TITLE
Let PHP handle no arguments.

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -695,18 +695,13 @@ final class Period implements JsonSerializable
      *
      * The resultant object englobes the largest duration possible.
      *
-     * @param \League\Period\Period $arg,... one or more Period objects
-     *
-     * @throws \RuntimeException If no argument is passed to the function
+     * @param \League\Period\Period $period... one or more Period objects
      *
      * @return \League\Period\Period
      */
-    public function merge()
+    public function merge($period)
     {
         $periods = func_get_args();
-        if (empty($periods)) {
-            throw new RuntimeException('At least one Period object must be given.');
-        }
 
         return array_reduce($periods, function (Period $carry, Period $period) {
             if ($carry->startDate > $period->startDate) {


### PR DESCRIPTION
PHP can handle when arguments aren't specified it-self.

Can add `@SuppressWarnings(PHPMD.UnusedLocalVariable)` if needed for `$period` that's unused.