### PR TITLE
Period::contains edge checking is confusing

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -449,7 +449,7 @@ class Period implements JsonSerializable
 
         $datetime = static::filterDatePoint($index);
 
-        return $datetime >= $this->startDate && $datetime < $this->endDate;
+        return $datetime >= $this->startDate && $datetime <= $this->endDate;
     }
 
     /**


### PR DESCRIPTION
There is some weirdness with edge checking that I've encountered.

Consider the following:
```
Period::createFromYear(2015)->contains(Period::createFromQuarter(2015, 4));
```
What would you think that should return?
I would say `true`, but the current implementation will return `false`. This seems very counterintuitive, given the example.

Thoughts? 

I realise this PR fails the tests. It's just for a discussion starting point.