### PR TITLE
Support pushing an entire Period instance forward or backwards in time

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -912,6 +912,19 @@ class Period implements JsonSerializable
     }
 
     /**
+     * Returns a new Period instance where the start/end dates have moved forwards in time by the given DateInterval
+     *
+     * @param DateInterval|int|string $interval The interval
+     * @return Period
+     */
+    public function move($interval)
+    {
+        $interval = static::filterDateInterval($interval);
+
+        return new static($this->startDate->add($interval), $this->endDate->add($interval));
+    }
+
+    /**
      * Create a new instance given two datepoints
      *
      * The datepoints will be used as to allow the creation of

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -918,4 +918,34 @@ class PeriodTest extends TestCase
         $this->assertEquals(3600, $res[1]->getTimestampInterval());
         $this->assertEquals(3600, $res[0]->getTimestampInterval());
     }
+
+    public function testMove()
+    {
+        $period = new Period('2016-01-01 15:32:12', '2016-01-15 12:00:01');
+        $moved = $period->move(new DateInterval('P1D'));
+        $this->assertEquals(new Period('2016-01-02 15:32:12', '2016-01-16 12:00:01'), $moved);
+    }
+
+    public function testMoveSupportStringIntervals()
+    {
+        $period = new Period('2016-01-01 15:32:12', '2016-01-15 12:00:01');
+        $advanced = $period->move('1 DAY');
+        $this->assertEquals(new Period('2016-01-02 15:32:12', '2016-01-16 12:00:01'), $advanced);
+    }
+
+    public function testMoveWithInvertedInterval()
+    {
+        $period = new Period('2016-01-02 15:32:12', '2016-01-16 12:00:01');
+        $lessOneDay = new DateInterval('P1D');
+        $lessOneDay->invert = true;
+        $moved = $period->move($lessOneDay);
+        $this->assertEquals(new Period('2016-01-01 15:32:12', '2016-01-15 12:00:01'), $moved);
+    }
+
+    public function testMoveWithInvertedStringInterval()
+    {
+        $period = new Period('2016-01-02 15:32:12', '2016-01-16 12:00:01');
+        $moved = $period->move('- 1 day');
+        $this->assertEquals(new Period('2016-01-01 15:32:12', '2016-01-15 12:00:01'), $moved);
+    }
 }


### PR DESCRIPTION
## Introduction

Currently, if you wish to advance a Period instance forward or backwards in time, this must be implemented in userland.

An example would be wanting to advance `Period('2016-01-01', '2016-07-07')` `forward 5 days`, to result in `Period('2016-06-01', '2016-07-12')`

## Proposal 

This PR adds new `advance(DateInterval $by)` and `recede(DateInterval $by)` methods to `Period`, which perform the operation described above.

For example:

```php
$period = new Period('2016-01-01 15:32:12', '2016-01-15 12:00:01');
$moved = $period->advance(new DateInterval('P1D')); // new Period('2016-01-02 15:32:12', '2016-01-16 12:00:01')
```
### Backward Incompatible Changes

There are no BC breaks.

### Targeted release version

The next release.

### PR Impact

None

## Open issues

None

