### PR TITLE
Adding Period::moveStartDate and Period::moveEndDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All Notable changes to `Period` will be documented in this file
 
+## Next
+
+### Added
+
+- `Period::move`
+- `Period::moveStartDate`
+- `Period::moveEndDate`
+
+### Fixed
+
+- None
+
+### Deprecated
+
+- `Period::add` you should use `Period::moveEndDate` instead
+- `Period::sub` you should use `Period::moveEndDate` instead
+
+### Removed
+
+- None
+
 ## 3.2.0 - 2016-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@ Period
 [![Latest Version](https://img.shields.io/github/release/thephpleague/period.svg?style=flat-square)](https://github.com/thephpleague/period/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![Build Status](https://img.shields.io/travis/thephpleague/period/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/period)
-[![HHVM Status](https://img.shields.io/hhvm/league/period.svg?style=flat-square)](http://hhvm.h4cc.de/package/league/period)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/thephpleague/period.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/period/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/thephpleague/period.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/period)
 [![Total Downloads](https://img.shields.io/packagist/dt/league/period.svg?style=flat-square)](https://packagist.org/packages/league/period)
 
-Period is PHP's missing Time Range API. It is based on [Resolving Feature Envy in the Domain](http://verraes.net/2014/08/resolving-feature-envy-in-the-domain/) by Mathias Verraes and extends the concept to cover all basic operations regarding time ranges.
+`Period` is PHP's missing time range API. It is based on [Resolving Feature Envy in the Domain](http://verraes.net/2014/08/resolving-feature-envy-in-the-domain/) by Mathias Verraes and extends the concept to cover all basic operations regarding time ranges.
 
 ## Highlights
 
-- Treats Time Range as immutable value objects
+- Treats a time range as an immutable value object
 - Exposes many named constructors to ease time range creation
 - Covers all basic manipulations related to time range
 - Fully documented
@@ -29,7 +28,7 @@ Full documentation can be found at [period.thephpleague.com](http://period.theph
 System Requirements
 -------
 
-You need **PHP >= 5.5.9** but the latest stable version of PHP or HHVM is recommended.
+You need **PHP >= 5.5.9** but the latest stable version of PHP is recommended.
 
 Install
 -------
@@ -43,7 +42,7 @@ $ composer require league/period
 Testing
 -------
 
-`League\Period` has a [PHPUnit](https://phpunit.de) test suite and a coding style compliance test suite using [PHP CS Fixer](http://cs.sensiolabs.org/). To run the tests, run the following command from the project folder.
+`Period` has a [PHPUnit](https://phpunit.de) test suite and a coding style compliance test suite using [PHP CS Fixer](http://cs.sensiolabs.org/). To run the tests, run the following command from the project folder.
 
 ``` bash
 $ composer test
@@ -52,7 +51,7 @@ $ composer test
 Contributing
 -------
 
-Contributions are welcome and will be fully credited. Please see [CONTRIBUTING](CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.
+Contributions are welcome and will be fully credited. Please see [CONTRIBUTING](.github/CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.
 
 Security
 -------

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -741,6 +741,32 @@ class PeriodTest extends TestCase
         Period::createFromDuration('2012-01-01', '1 MONTH')->add('-3 MONTHS');
     }
 
+    public function testMoveStartDateBackward()
+    {
+        $orig = Period::createFromMonth(2012, 1);
+        $period = $orig->moveStartDate('-1 MONTH');
+        $this->assertTrue($period->durationGreaterThan($orig));
+        $this->assertEquals($orig->getEndDate(), $period->getEndDate());
+        $this->assertNotEquals($orig->getStartDate(), $period->getStartDate());
+    }
+
+    public function testMoveStartDateForward()
+    {
+        $orig = Period::createFromMonth(2012, 1);
+        $period = $orig->moveStartDate('2 WEEKS');
+        $this->assertTrue($period->durationLessThan($orig));
+        $this->assertEquals($orig->getEndDate(), $period->getEndDate());
+        $this->assertNotEquals($orig->getStartDate(), $period->getStartDate());
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testMoveStartDateThrowsLogicException()
+    {
+        Period::createFromDuration('2012-01-01', '1 MONTH')->moveStartDate('3 MONTHS');
+    }
+
     public function testSub()
     {
         $orig = Period::createFromDuration('2012-01-01', '1 MONTH');


### PR DESCRIPTION
## Introduction

With `Period::move` added to the class we need a mechanism to update each Period endpoint independently using an `DateInterval`.

## Proposal 

### Describe the new feature

We are adding two methods:

```php
<?php

public Period::moveStartDate($interval): Period
public Period::moveEndDate($interval): Period
```

Both methods move the endpoint according to a given interval. Depending on the `DateInterval->invert` property, the interval is either added or removed from the specified endpoint.

### Backward Incompatible Changes
 
None in the current major version. 

### Targeted release version

3.3

### PR Impact

The following methods are deprecated

- `Period::add`
- `Period::sub`

which are misleading in their name as they both represent a subset of `Period::moveEndDate`.
These methods will be remove from the next major release.

## Open issues

None