### PR TITLE
Add PeriodCollection to fetch gaps within time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,15 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.5
-      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false
-    - php: 5.6
-      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true
     - php: 7.0
-      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false
+      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true
     - php: 7.1
-      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false
+      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true
     - php: hhvm
       env: COLLECT_COVERAGE=false VALIDATE_CODING_STYLE=false
   fast_finish: true
+  allow_failures:
+    - php: hhvm
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/thephpleague/period/issues"
     },
     "require": {
-        "php" : ">=5.5.9"
+        "php" : "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^4.0",

--- a/src/PeriodCollection.php
+++ b/src/PeriodCollection.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace League\Period;
+
+/**
+ * Class PeriodCollection
+ * @package League\Period
+ * @abstract perform actions on a collection of Periods
+ */
+final class PeriodCollection
+{
+
+    private $periods;
+
+    public function __construct(
+        array $periods
+    ) {
+        foreach ($periods as $key => $potentialPeriod) {
+            if (!$potentialPeriod instanceof Period) {
+                throw new \InvalidArgumentException('Must receive a Period object. Received: ' . get_class($potentialPeriod));
+            }
+        }
+
+        $this->periods = $periods;
+    }
+
+    /**
+     * @abstract find the available gaps given a collection of periods
+     * @return Period[]
+     */
+    public function invert(): array
+    {
+        $out = [];
+        $sortedPeriods = $this->sort(true);
+
+        $lastIndex = count($sortedPeriods) - 1;
+
+        /**
+         * @var Period $currentPeriod
+         * @var Period $nextPeriod
+         */
+        foreach ($sortedPeriods as $key => $currentPeriod) {
+            if ($key == $lastIndex) {
+                break;
+            }
+            $next = $key + 1;
+            $nextPeriod = $sortedPeriods[$next];
+
+            // skip if the next period contains this one
+            if ($currentPeriod->abuts($nextPeriod) || $currentPeriod->overlaps($nextPeriod)) {
+                continue;
+            }
+            $out[] = $currentPeriod->gap($nextPeriod);
+        }
+
+
+        return $out;
+    }
+
+    public function sort(bool $consolidate = false): array
+    {
+        $out = $this->periods;
+
+        usort($out, function (Period $periodA, Period $periodB) {
+            if ($periodA->isBefore($periodB)) {
+                return -1;
+            }
+            if ($periodA->isAfter($periodB)) {
+                return 1;
+            }
+
+            return 0;
+        });
+
+        if ($consolidate === true) {
+            $lastIndex = count($out) - 1;
+            $updatedOut = [];
+            /**
+             * @var Period $currentPeriod
+             * @var Period $nextPeriod
+             */
+            foreach ($out as $key => $currentPeriod) {
+
+                if ($key == $lastIndex) {
+                    $updatedOut[] = $currentPeriod;
+                    break;
+                }
+                $next = $key + 1;
+                $nextPeriod = $out[$next];
+
+                // skip if the next period contains this one
+                if ($currentPeriod->contains($nextPeriod)) {
+                    //continue;
+                }
+                if ($nextPeriod->contains($currentPeriod)) {
+                    continue;
+                }
+                $updatedOut[] = $currentPeriod;
+            }
+            $out = $updatedOut;
+        }
+
+        return $out;
+    }
+
+}

--- a/test/PeriodCollectionTest.php
+++ b/test/PeriodCollectionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace League\Period\Test;
+
+use League\Period\Period;
+use League\Period\PeriodCollection;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class PeriodCollectionTest extends TestCase
+{
+    public function setUp()
+    {
+
+    }
+
+
+    public function testSort()
+    {
+        $period1 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T00:00:00Z'), '1 HOUR');
+        $period2 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T01:30:00Z'), '30 MINUTES');
+        $period3 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T02:45:00Z'), '1 HOUR');
+
+        $periods = [
+            0 => $period3,
+            1 => $period2,
+            2 => $period1
+        ];
+
+
+        $periodCollection = new PeriodCollection($periods);
+        $sortedOutput = $periodCollection->sort();
+        $this->assertInternalType('array', $sortedOutput);
+        $this->assertCount(3, $sortedOutput);
+
+        $this->assertEquals($periods[2], $sortedOutput[0]);
+        $this->assertEquals($periods[1], $sortedOutput[1]);
+        $this->assertEquals($periods[0], $sortedOutput[2]);
+
+    }
+
+
+    public function testSortAndConsolidate()
+    {
+        $period1 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T00:00:00Z'), '1 HOUR');
+        $period2 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T01:30:00Z'), '30 MINUTES');
+        $period3 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T02:45:00Z'), '1 HOUR');
+        $period4 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T02:45:00Z'), '1 HOUR');
+        $period5 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T02:45:00Z'), '1 HOUR');
+
+        $periods = [
+            0 => $period3,
+            1 => $period2,
+            2 => $period1,
+            3 => $period4,
+            4 => $period5
+        ];
+
+        $periodCollection = new PeriodCollection($periods);
+        $sortedOutput = $periodCollection->sort(true);
+
+        $this->assertInternalType('array', $sortedOutput);
+        $this->assertCount(3, $sortedOutput);
+
+        $this->assertEquals($periods[2], $sortedOutput[0]);
+        $this->assertEquals($periods[1], $sortedOutput[1]);
+        $this->assertEquals($periods[0], $sortedOutput[2]);
+    }
+
+
+    public function testInvert()
+    {
+        $period1 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T00:00:00Z'), '1 HOUR');
+        $period2 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T01:30:00Z'), '30 MINUTES');
+        $period3 = Period::createFromDuration(\DateTime::createFromFormat(\DateTime::ISO8601,
+            '2016-01-01T02:45:00Z'), '1 HOUR');
+
+        $this->periods = [
+            0 => $period3,
+            1 => $period2,
+            2 => $period1
+        ];
+
+        $collection = new PeriodCollection($this->periods);
+        $invertedResponse = $collection->invert();
+        $this->assertInternalType('array', $invertedResponse);
+        $this->assertCount(2, $collection->invert());
+
+        foreach ($invertedResponse as $key => $value) {
+            $this->assertInstanceOf(Period::class, $value);
+        }
+
+        $this->assertEquals($period1->gap($period2), $invertedResponse[0]);
+        $this->assertEquals($period2->gap($period3), $invertedResponse[1]);
+
+    }
+
+}


### PR DESCRIPTION
## Introduction

Add the ability to perform inversion and linear sorting off of a collection of Periods.

### Describe the new/updated/fixed feature

PeriodCollection->invert() --> given a collection of periods ... find the gaps between all of them.
PeriodCollection->sort(false) --> sort from earliest to latest
PeriodCollection->sort(true) --> sort form earliest to latest and converge periods that contain eachother.

### Targeted release version
Next minor.

### PR Impact

New functionality added to a new class.

## Open issues
Currently relies on PHP 7+ with the declared strict types.
