### PR TITLE
PHPDoc - Return typehint for split()

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -888,7 +888,7 @@ class Period implements JsonSerializable
      *
      * @param DateInterval|int|string $interval The interval
      *
-     * @return Generator
+     * @return Generator|Period[]
      */
     public function split($interval)
     {


### PR DESCRIPTION
## Introduction

Very small change - Allow IDEs to know that each ` $period` returned by `split()` in a foreach loop is instance of `Period`.

## Proposal 

Added a Period[] typehint in the PHPDoc block, in addition to `Generator`.

### Describe the new/updated/fixed feature

I don't think further description is needed :)

### Backward Incompatible Changes

Nope.

### Targeted release version

As you like.

### PR Impact

No code impact.

## Open issues

None.
