### PR TITLE
New feature: split() with backwards option

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -877,7 +877,7 @@ class Period implements JsonSerializable
     }
 
     /**
-     * Split a Period by a given interval
+     * Split a Period by a given interval (from start to end)
      *
      * The interval can be
      * <ul>
@@ -903,6 +903,35 @@ class Period implements JsonSerializable
 
             $startDate = $endDate;
         } while ($startDate < $this->endDate);
+    }
+
+    /**
+     * Split a Period by a given interval (from end to start)
+     *
+     * The interval can be
+     * <ul>
+     * <li>a DateInterval object</li>
+     * <li>an int interpreted as the duration expressed in seconds.</li>
+     * <li>a string in a format supported by DateInterval::createFromDateString</li>
+     * </ul>
+     *
+     * @param DateInterval|int|string $interval The interval
+     *
+     * @return Generator|Period[]
+     */
+    public function splitBackwards($interval)
+    {
+        $endDate = $this->endDate;
+        $interval = static::filterDateInterval($interval);
+        do {
+            $startDate = $endDate->sub($interval);
+            if ($startDate < $this->startDate) {
+                $startDate = $this->startDate;
+            }
+            yield new static($startDate, $endDate);
+
+            $endDate = $startDate;
+        } while ($endDate > $this->startDate);
     }
 
     /**

--- a/test/PeriodTest.php
+++ b/test/PeriodTest.php
@@ -154,6 +154,68 @@ class PeriodTest extends TestCase
         $this->assertEquals(14400, $last->getTimestampInterval());
     }
 
+    public function testSplitData()
+    {
+        $period = Period::createFromDuration(new DateTime('2015-01-01'), '3 days');
+        $range = $period->split('1 day');
+        $result = array_map(function (Period $range) {
+            return [
+                'start' => $range->getStartDate()->format('Y-m-d H:i:s'),
+                'end'   => $range->getEndDate()->format('Y-m-d H:i:s')
+            ];
+        }, iterator_to_array($range));
+        $expected = [
+            [
+                'start' => '2015-01-01 00:00:00',
+                'end'   => '2015-01-02 00:00:00',
+            ],
+            [
+                'start' => '2015-01-02 00:00:00',
+                'end'   => '2015-01-03 00:00:00',
+            ],
+            [
+                'start' => '2015-01-03 00:00:00',
+                'end'   => '2015-01-04 00:00:00',
+            ],
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    public function testSplitDataBackwards()
+    {
+        $period = Period::createFromDuration(new DateTime('2015-01-01'), '3 days');
+        $range = $period->splitBackwards('1 day');
+        $result = array_map(function (Period $range) {
+            return [
+                'start' => $range->getStartDate()->format('Y-m-d H:i:s'),
+                'end'   => $range->getEndDate()->format('Y-m-d H:i:s')
+            ];
+        }, iterator_to_array($range));
+        $expected = [
+            [
+                'start' => '2015-01-03 00:00:00',
+                'end'   => '2015-01-04 00:00:00',
+            ],
+            [
+                'start' => '2015-01-02 00:00:00',
+                'end'   => '2015-01-03 00:00:00',
+            ],
+            [
+                'start' => '2015-01-01 00:00:00',
+                'end'   => '2015-01-02 00:00:00',
+            ],
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    public function testSplitBackwardsWithInconsistentInterval()
+    {
+        $period = Period::createFromDuration('2010-01-01', '1 DAY');
+        $range = iterator_to_array($period->splitBackwards('10 HOURS'));
+        $last = array_pop($range);
+        $this->assertEquals(14400, $last->getTimestampInterval());
+    }
+
     public function testSetState()
     {
         if (!method_exists(DateTimeImmutable::class, '__set_state')) {


### PR DESCRIPTION
## Introduction

This PR enables an optionnal backwards feature on the `split()` method.

## Proposal 

```php
foreach ($period->split('1 hour', true) as $period) {
    // ... the loop will start from endDate to startDate
}
```

### Describe the new/updated/fixed feature

When set to `true` (defaults to `false` to keep BC), the `split()` method will start to yield periods from the most recent one.

### Backward Incompatible Changes

Nope, maybe excepted for developers who overrid the class and changed that method signature already.

### Targeted release version

Next minor version.
