### PR TITLE
Typo fix ("larget" -> "largest")

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -781,7 +781,7 @@ final class Period implements PeriodInterface
 
     /**
 
-     * Returns a Period whose endpoints are the larget possible
+     * Returns a Period whose endpoints are the largest possible
      * between 2 instance of Period objects
      *
      * @param Period $carry


### PR DESCRIPTION
This is just a fix of a typo inside of phpdoc