### PR TITLE
add helper functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 matrix:
   include:
+    - php: 7.1
+      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false RUN_PHPSTAN=false IGNORE_PLATFORMS=false
     - php: 7.2
       env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true RUN_PHPSTAN=true IGNORE_PLATFORMS=false
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 matrix:
   include:
     - php: 7.1
-      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false RUN_PHPSTAN=false IGNORE_PLATFORMS=false
+      env: COLLECT_COVERAGE=false VALIDATE_CODING_STYLE=false RUN_PHPSTAN=false IGNORE_PLATFORMS=false
     - php: 7.2
       env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true RUN_PHPSTAN=true IGNORE_PLATFORMS=false
     - php: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,30 @@ All Notable changes to `Period` will be documented in this file
 
 ### Added
 
-- `Interval` interface
 - `Exception` class
-- `Period::createFromDatePeriod`
-- `Period::createFromISOYear`
-- `Period::createFromISOWeek`
-- `Period::createFromHour`
-- `Period::createFromMinute`
-- `Period::createFromSecond`
-- `Period::createFromInstant`
 - `Period::createFromDurationAfterStart`
 - `Period::withDurationAfterStart`
 - `Period::expand`
-- `Period::equalsTo`
-- `League\Period\duration` and `League\Period\datepoint` functions
+- `Period::equals`
+- `Period::createFromDatePeriod`
+
+#### Helper functions
+
+- `League\Period\year`
+- `League\Period\semester`
+- `League\Period\quarter`
+- `League\Period\month`
+- `League\Period\day`
+- `League\Period\hour`
+- `League\Period\minute`
+- `League\Period\second`
+- `League\Period\instant`
+- `League\Period\iso_year`
+- `League\Period\iso_week`
+- `League\Period\interval_after`
+- `League\Period\interval_before`
+- `League\Period\duration`
+- `League\Period\datepoint`
 
 ### Fixed
 
@@ -35,7 +45,13 @@ All Notable changes to `Period` will be documented in this file
 
 ### Deprecated
 
-- None
+- `Period::createFromYear` use instead `League\Period\year`
+- `Period::createFromMonth` use instead `League\Period\month`
+- `Period::createFromDay` use instead `League\Period\day`
+- `Period::createFromSemester` use instead `League\Period\semester`
+- `Period::createFromQuarter` use instead `League\Period\quarter`
+- `Period::createFromDurationAfterStart` use instead `League\Period\interval_after`
+- `Period::createFromDurationBeforeEnd` use instead `League\Period\interval_before`
 
 ### Removed
 
@@ -43,10 +59,10 @@ All Notable changes to `Period` will be documented in this file
 - `Period::previous`
 - `Period::add`
 - `Period::sub`
-- `Period::sameValueAs` replaced by `Period::equalsTo`
-- `Period::createFromDuration` replaced by `Period::createFromDurationAfterStart`
+- `Period::sameValueAs` replaced by `Period::equals`
+- `Period::createFromDuration` replaced by `League\Period\interval_after`
 - `Period::withDuration` replaced by `Period::withDurationAfterStart`
-- `Period::createFromWeek` replaced by `Period::createFromISOWeek`
+- `Period::createFromWeek` replaced by `League\Period\iso_week`
 - Support for PHP 7.0 and PHP 7.1
 
 ## 3.4.0 - 2017-11-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All Notable changes to `Period` will be documented in this file
 - `Period::equals`
 - `Period::durationCompare`
 - `Period::durationEquals`
-- `Period::createFromDatePeriod`
+- `Period::fromDatePeriod`
+- `League\Period\datepoint`
+- `League\Period\duration`
 - `League\Period\year`
 - `League\Period\semester`
 - `League\Period\quarter`
@@ -25,8 +27,7 @@ All Notable changes to `Period` will be documented in this file
 - `League\Period\iso_week`
 - `League\Period\interval_after`
 - `League\Period\interval_before`
-- `League\Period\duration`
-- `League\Period\datepoint`
+- `League\Period\interval_around`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All Notable changes to `Period` will be documented in this file
 - `Exception` class
 - `Period::expand`
 - `Period::equals`
+- `Period::durationCompare`
+- `Period::durationEquals`
 - `Period::createFromDatePeriod`
 - `League\Period\year`
 - `League\Period\semester`
@@ -51,6 +53,8 @@ All Notable changes to `Period` will be documented in this file
 - `Period::add`
 - `Period::sub`
 - `Period::sameValueAs` replaced by `Period::equals`
+- `Period::sameDurationAs` replaced by `Period::durationEquals`
+- `Period::compareDuration` replaced by `Period::durationCompare`
 - `Period::withDuration` replaced by `Period::withDurationAfterStart`
 - Support for PHP 7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,9 @@ All Notable changes to `Period` will be documented in this file
 ### Added
 
 - `Exception` class
-- `Period::createFromDurationAfterStart`
-- `Period::withDurationAfterStart`
 - `Period::expand`
 - `Period::equals`
 - `Period::createFromDatePeriod`
-
-#### Helper functions
-
 - `League\Period\year`
 - `League\Period\semester`
 - `League\Period\quarter`
@@ -34,36 +29,30 @@ All Notable changes to `Period` will be documented in this file
 ### Fixed
 
 - The `Period` class is now final
-- The following named constructors now accept as its sole argument a `DateTimeInterface` object.
-    - `Period::createFromYear`
-    - `Period::createFromMonth`
-    - `Period::createFromDay`
-    - `Period::createFromSemester`
-    - `Period::createFromQuarter`
 - `Period::JsonSerialize` now returns datepoint in JavaScript compatible datetime notation
 - `Period::diff` always returns an array containing two values.
 
 ### Deprecated
 
-- `Period::createFromYear` use instead `League\Period\year`
-- `Period::createFromMonth` use instead `League\Period\month`
-- `Period::createFromDay` use instead `League\Period\day`
-- `Period::createFromSemester` use instead `League\Period\semester`
-- `Period::createFromQuarter` use instead `League\Period\quarter`
-- `Period::createFromDurationAfterStart` use instead `League\Period\interval_after`
-- `Period::createFromDurationBeforeEnd` use instead `League\Period\interval_before`
+- None
 
 ### Removed
 
+- `Period::createFromYear` use instead `League\Period\year`
+- `Period::createFromMonth` use instead `League\Period\month`
+- `Period::createFromWeek` replaced by `League\Period\iso_week`
+- `Period::createFromDay` use instead `League\Period\day`
+- `Period::createFromSemester` use instead `League\Period\semester`
+- `Period::createFromQuarter` use instead `League\Period\quarter`
+- `Period::createFromDuration` use instead `League\Period\interval_after`
+- `Period::createFromDurationBeforeEnd` use instead `League\Period\interval_before`
 - `Period::next`
 - `Period::previous`
 - `Period::add`
 - `Period::sub`
 - `Period::sameValueAs` replaced by `Period::equals`
-- `Period::createFromDuration` replaced by `League\Period\interval_after`
 - `Period::withDuration` replaced by `Period::withDurationAfterStart`
-- `Period::createFromWeek` replaced by `League\Period\iso_week`
-- Support for PHP 7.0 and PHP 7.1
+- Support for PHP 7.0
 
 ## 3.4.0 - 2017-11-17
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/thephpleague/period/issues"
     },
     "require": {
-        "php" : ">=7.2.0"
+        "php" : ">=7.1.3"
     },
     "require-dev": {
         "phpunit/phpunit" : "^7.0",

--- a/phpstan.src.neon
+++ b/phpstan.src.neon
@@ -3,6 +3,6 @@ includes:
 parameters:
     ignoreErrors:
         - '#Instanceof between DateTimeInterface and DateTimeInterface will always evaluate to true.#'
-        - '#Method League\\Period\\Period::(createFrom|get)[A-Z][A-Za-z]+\(\) has parameter \$(datepoint|duration|startDate|endDate) with no typehint specified.#'
+        - '#Method League\\Period\\Period::[a-z][A-Za-z_]+\(\) has parameter \$(datepoint|duration|startDate|endDate|index) with no typehint specified.#'
         - '#Function League\\Period\\[a-z][A-Za-z_]+\(\) has parameter \$(datepoint|duration|startDate|endDate) with no typehint specified.#'
     reportUnmatchedIgnoredErrors: true

--- a/phpstan.src.neon
+++ b/phpstan.src.neon
@@ -4,5 +4,5 @@ parameters:
     ignoreErrors:
         - '#Instanceof between DateTimeInterface and DateTimeInterface will always evaluate to true.#'
         - '#Method League\\Period\\Period::(createFrom|get)[A-Z][A-Za-z]+\(\) has parameter \$(datepoint|duration|startDate|endDate) with no typehint specified.#'
-        - '#Function League\\Period\\(datepoint|duration)\(\) has parameter \$(datepoint|duration) with no typehint specified.#'
+        - '#Function League\\Period\\[a-z][A-Za-z_]+\(\) has parameter \$(datepoint|duration|startDate|endDate) with no typehint specified.#'
     reportUnmatchedIgnoredErrors: true

--- a/src/Period.php
+++ b/src/Period.php
@@ -23,7 +23,6 @@ use DateTimeInterface;
 use DateTimeZone;
 use JsonSerializable;
 use function array_unshift;
-use function intdiv;
 use function sprintf;
 
 /**
@@ -98,242 +97,114 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance from a starting point and an interval.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.0.0
+     *
+     * @see \League\Period\interval_after
      */
     public static function createFromDurationAfterStart($startDate, $duration): self
     {
-        $startDate = datepoint($startDate);
-
-        return new Period($startDate, $startDate->add(duration($duration)));
+        return interval_after($startDate, $duration);
     }
 
     /**
      * Creates new instance from a ending excluded datepoint and an interval.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.0.0
+     *
+     * @see \League\Period\interval_before
      */
     public static function createFromDurationBeforeEnd($endDate, $duration): self
     {
-        $endDate = datepoint($endDate);
-
-        return new Period($endDate->sub(duration($duration)), $endDate);
+        return interval_before($endDate, $duration);
     }
 
     /**
      * Creates new instance for a specific year.
      *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.0.0
+     *
+     * @see \League\Period\year
+     *
      * @param mixed $int_or_datepoint a year as an int or a datepoint
      */
     public static function createFromYear($int_or_datepoint): self
     {
-        if (is_int($int_or_datepoint)) {
-            $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setDate($int_or_datepoint, 1, 1);
-
-            return new self($startDate, $startDate->add(new DateInterval('P1Y')));
-        }
-
-        $datepoint = datepoint($int_or_datepoint);
-        $startDate = $datepoint->setTime(0, 0, 0, 0)->setDate((int) $datepoint->format('Y'), 1, 1);
-
-        return new self($startDate, $startDate->add(new DateInterval('P1Y')));
-    }
-
-    /**
-     * Creates new instance for a specific ISO year.
-     *
-     * @param mixed $int_or_datepoint a year as an int or a datepoint
-     */
-    public static function createFromISOYear($int_or_datepoint): self
-    {
-        if (is_int($int_or_datepoint)) {
-            $datepoint = (new DateTimeImmutable())->setTime(0, 0, 0, 0);
-
-            return new self(
-                $datepoint->setISODate($int_or_datepoint, 1, 1),
-                $datepoint->setISODate(++$int_or_datepoint, 1, 1)
-            );
-        }
-
-        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
-        $int_or_datepoint = (int) $datepoint->format('o');
-
-        return new self(
-            $datepoint->setISODate($int_or_datepoint, 1, 1),
-            $datepoint->setISODate(++$int_or_datepoint, 1, 1)
-        );
+        return year($int_or_datepoint);
     }
 
     /**
      * Creates new instance for a specific semester in a given year.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.0.0
+     *
+     * @see \League\Period\semester
      *
      * @param mixed    $int_or_datepoint a year as an int or a datepoint
      * @param null|int $index            a semester index from 1 to 2 included
      */
     public static function createFromSemester($int_or_datepoint, int $index = null): self
     {
-        if (!is_int($int_or_datepoint)) {
-            $datepoint = datepoint($int_or_datepoint);
-            $startDate = $datepoint->setTime(0, 0, 0, 0)->setDate(
-                (int) $datepoint->format('Y'),
-                (intdiv((int) $datepoint->format('n'), 6) * 6) + 1,
-                1
-            );
-
-            return new self($startDate, $startDate->add(new DateInterval('P6M')));
-        }
-
-        if (null !== $index && 0 < $index && 2 >= $index) {
-            $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)
-                ->setDate($int_or_datepoint, (($index - 1) * 6) + 1, 1);
-
-            return new self($startDate, $startDate->add(new DateInterval('P6M')));
-        }
-
-        throw new Exception('The semester index is not contained within the valid range.');
+        return semester($int_or_datepoint, $index);
     }
 
     /**
      * Creates new instance for a specific quarter in a given year.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.0.0
+     *
+     * @see \League\Period\quarter
      *
      * @param mixed    $int_or_datepoint a year as an int or a datepoint
      * @param null|int $index            quarter index from 1 to 4 included
      */
     public static function createFromQuarter($int_or_datepoint, int $index = null): self
     {
-        if (!is_int($int_or_datepoint)) {
-            $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
-            $startDate = $datepoint->setDate(
-                (int) $datepoint->format('Y'),
-                (intdiv((int) $datepoint->format('n'), 3) * 3) + 1,
-                1
-            );
-
-            return new self($startDate, $startDate->add(new DateInterval('P3M')));
-        }
-
-        if (null !== $index && 0 < $index && 4 >= $index) {
-            $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)
-                ->setDate($int_or_datepoint, (($index - 1) * 3) + 1, 1);
-
-            return new self($startDate, $startDate->add(new DateInterval('P3M')));
-        }
-
-        throw new Exception('The quarter index is not contained within the valid range.');
+        return quarter($int_or_datepoint, $index);
     }
 
     /**
      * Creates new instance for a specific year and month.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.0.0
+     *
+     * @see \League\Period\month
      *
      * @param mixed    $int_or_datepoint a year as an int or a datepoint
      * @param int|null $index            month index from 1 to 12 included
      */
     public static function createFromMonth($int_or_datepoint, int $index = null): self
     {
-        if (!is_int($int_or_datepoint)) {
-            $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
-            $startDate = $datepoint->setDate((int) $datepoint->format('Y'), (int) $datepoint->format('n'), 1);
-
-            return new self($startDate, $startDate->add(new DateInterval('P1M')));
-        }
-
-        if (null !== $index && 0 < $index && 12 >= $index) {
-            $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setDate($int_or_datepoint, $index, 1);
-
-            return new self($startDate, $startDate->add(new DateInterval('P1M')));
-        }
-
-        throw new Exception('The month index is not contained within the valid range.');
-    }
-
-    /**
-     * Creates new instance for a specific ISO8601 week.
-     *
-     * @param mixed    $int_or_datepoint a year as an int or a datepoint
-     * @param int|null $index            index from 1 to 53 included
-     */
-    public static function createFromISOWeek($int_or_datepoint, int $index = null): self
-    {
-        if (!is_int($int_or_datepoint)) {
-            $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
-            $startDate = $datepoint->setISODate((int) $datepoint->format('o'), (int) $datepoint->format('W'), 1);
-
-            return new self($startDate, $startDate->add(new DateInterval('P7D')));
-        }
-
-        if (null !== $index && 0 < $index && 53 >= $index) {
-            $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setISODate($int_or_datepoint, $index, 1);
-
-            return new self($startDate, $startDate->add(new DateInterval('P7D')));
-        }
-
-        throw new Exception('The week index is not contained within the valid range.');
+        return month($int_or_datepoint, $index);
     }
 
     /**
      * Creates new instance for a specific date.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.0.0
+     *
+     * @see \League\Period\day
      *
      * The date is truncated so that the time range starts at midnight
      * according to the date timezone and last a full day.
      */
     public static function createFromDay($datepoint): self
     {
-        $startDate = datepoint($datepoint)->setTime(0, 0, 0, 0);
-
-        return new self($startDate, $startDate->add(new DateInterval('P1D')));
-    }
-
-    /**
-     * Creates new instance for a specific date and hour.
-     *
-     * The starting datepoint represents the beginning of the hour
-     * The interval is equal to 1 hour
-     */
-    public static function createFromHour($datepoint): self
-    {
-        $datepoint = datepoint($datepoint);
-        $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0, 0, 0);
-
-        return new self($startDate, $startDate->add(new DateInterval('PT1H')));
-    }
-
-    /**
-     * Creates new instance for a specific date, hour and minute.
-     *
-     * The starting datepoint represents the beginning of the minute
-     * The interval is equal to 1 minute
-     */
-    public static function createFromMinute($datepoint): self
-    {
-        $datepoint = datepoint($datepoint);
-        $startDate = $datepoint->setTime((int) $datepoint->format('H'), (int) $datepoint->format('i'), 0, 0);
-
-        return new self($startDate, $startDate->add(new DateInterval('PT1M')));
-    }
-
-    /**
-     * Creates new instance for a specific date, hour, minute and second.
-     *
-     * The starting datepoint represents the beginning of the second
-     * The interval is equal to 1 second
-     */
-    public static function createFromSecond($datepoint): self
-    {
-        $datepoint = datepoint($datepoint);
-        $startDate = $datepoint->setTime(
-            (int) $datepoint->format('H'),
-            (int) $datepoint->format('i'),
-            (int) $datepoint->format('s'),
-            0
-        );
-
-        return new self($startDate, $startDate->add(new DateInterval('PT1S')));
-    }
-
-    /**
-     * Creates new instance for a specific datepoint.
-     */
-    public static function createFromDatepoint($datepoint): self
-    {
-        $datepoint = datepoint($datepoint);
-
-        return new self($datepoint, $datepoint);
+        return day($datepoint);
     }
 
     /**
@@ -465,7 +336,7 @@ final class Period implements JsonSerializable
     /**
      * Tells whether two Interval share the same datepoints.
      */
-    public function equalsTo(Period $interval): bool
+    public function equals(Period $interval): bool
     {
         return $this->startDate == $interval->getStartDate()
             && $this->endDate == $interval->getEndDate();
@@ -665,7 +536,7 @@ final class Period implements JsonSerializable
      */
     public function diff(Period $interval): array
     {
-        if ($interval->equalsTo($this)) {
+        if ($interval->equals($this)) {
             return [null, null];
         }
 
@@ -776,7 +647,7 @@ final class Period implements JsonSerializable
     {
         $duration = duration($duration);
         $period = new self($this->startDate->add($duration), $this->endDate->add($duration));
-        if ($period->equalsTo($this)) {
+        if ($period->equals($this)) {
             return $this;
         }
 
@@ -798,7 +669,7 @@ final class Period implements JsonSerializable
     {
         $duration = duration($duration);
         $period = new self($this->startDate->sub($duration), $this->endDate->add($duration));
-        if ($period->equalsTo($this)) {
+        if ($period->equals($this)) {
             return $this;
         }
 

--- a/src/Period.php
+++ b/src/Period.php
@@ -51,6 +51,24 @@ final class Period implements JsonSerializable
     private $endDate;
 
     /**
+     * Creates new instance from a DatePeriod.
+     *
+     * @throws Exception If the submitted DatePeriod lacks an end datepoint.
+     *                   This is possible if the DatePeriod was created using
+     *                   recurrences instead of a end datepoint.
+     *                   https://secure.php.net/manual/en/dateperiod.getenddate.php
+     */
+    public static function createFromDatePeriod(DatePeriod $datePeriod): self
+    {
+        $endDate = $datePeriod->getEndDate();
+        if ($endDate instanceof DateTimeInterface) {
+            return new self($datePeriod->getStartDate(), $endDate);
+        }
+
+        throw new Exception('The submitted DatePeriod object does not contain an end datepoint');
+    }
+
+    /**
      * @inheritdoc
      */
     public static function __set_state(array $period)
@@ -75,136 +93,6 @@ final class Period implements JsonSerializable
         }
         $this->startDate = $startDate;
         $this->endDate = $endDate;
-    }
-
-    /**
-     * Creates new instance from a DatePeriod.
-     *
-     * @throws Exception If the submitted DatePeriod lacks an end datepoint.
-     *                   This is possible if the DatePeriod was created using
-     *                   recurrences instead of a end datepoint.
-     *                   https://secure.php.net/manual/en/dateperiod.getenddate.php
-     */
-    public static function createFromDatePeriod(DatePeriod $datePeriod): self
-    {
-        $endDate = $datePeriod->getEndDate();
-        if ($endDate instanceof DateTimeInterface) {
-            return new Period($datePeriod->getStartDate(), $endDate);
-        }
-
-        throw new Exception('The submitted DatePeriod object does not contain an end datepoint');
-    }
-
-    /**
-     * Creates new instance from a starting point and an interval.
-     *
-     * DEPRECATION WARNING! This method will be removed in the next major point release
-     *
-     * @deprecated deprecated since version 4.0.0
-     *
-     * @see \League\Period\interval_after
-     */
-    public static function createFromDurationAfterStart($startDate, $duration): self
-    {
-        return interval_after($startDate, $duration);
-    }
-
-    /**
-     * Creates new instance from a ending excluded datepoint and an interval.
-     *
-     * DEPRECATION WARNING! This method will be removed in the next major point release
-     *
-     * @deprecated deprecated since version 4.0.0
-     *
-     * @see \League\Period\interval_before
-     */
-    public static function createFromDurationBeforeEnd($endDate, $duration): self
-    {
-        return interval_before($endDate, $duration);
-    }
-
-    /**
-     * Creates new instance for a specific year.
-     *
-     * DEPRECATION WARNING! This method will be removed in the next major point release
-     *
-     * @deprecated deprecated since version 4.0.0
-     *
-     * @see \League\Period\year
-     *
-     * @param mixed $int_or_datepoint a year as an int or a datepoint
-     */
-    public static function createFromYear($int_or_datepoint): self
-    {
-        return year($int_or_datepoint);
-    }
-
-    /**
-     * Creates new instance for a specific semester in a given year.
-     *
-     * DEPRECATION WARNING! This method will be removed in the next major point release
-     *
-     * @deprecated deprecated since version 4.0.0
-     *
-     * @see \League\Period\semester
-     *
-     * @param mixed    $int_or_datepoint a year as an int or a datepoint
-     * @param null|int $index            a semester index from 1 to 2 included
-     */
-    public static function createFromSemester($int_or_datepoint, int $index = null): self
-    {
-        return semester($int_or_datepoint, $index);
-    }
-
-    /**
-     * Creates new instance for a specific quarter in a given year.
-     *
-     * DEPRECATION WARNING! This method will be removed in the next major point release
-     *
-     * @deprecated deprecated since version 4.0.0
-     *
-     * @see \League\Period\quarter
-     *
-     * @param mixed    $int_or_datepoint a year as an int or a datepoint
-     * @param null|int $index            quarter index from 1 to 4 included
-     */
-    public static function createFromQuarter($int_or_datepoint, int $index = null): self
-    {
-        return quarter($int_or_datepoint, $index);
-    }
-
-    /**
-     * Creates new instance for a specific year and month.
-     *
-     * DEPRECATION WARNING! This method will be removed in the next major point release
-     *
-     * @deprecated deprecated since version 4.0.0
-     *
-     * @see \League\Period\month
-     *
-     * @param mixed    $int_or_datepoint a year as an int or a datepoint
-     * @param int|null $index            month index from 1 to 12 included
-     */
-    public static function createFromMonth($int_or_datepoint, int $index = null): self
-    {
-        return month($int_or_datepoint, $index);
-    }
-
-    /**
-     * Creates new instance for a specific date.
-     *
-     * DEPRECATION WARNING! This method will be removed in the next major point release
-     *
-     * @deprecated deprecated since version 4.0.0
-     *
-     * @see \League\Period\day
-     *
-     * The date is truncated so that the time range starts at midnight
-     * according to the date timezone and last a full day.
-     */
-    public static function createFromDay($datepoint): self
-    {
-        return day($datepoint);
     }
 
     /**
@@ -261,7 +149,6 @@ final class Period implements JsonSerializable
     /**
      * Returns the string representation as a ISO8601 interval format.
      *
-     *
      * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
      *
      * @return string
@@ -276,7 +163,6 @@ final class Period implements JsonSerializable
     /**
      * Returns the Json representation of an instance using
      * the JSON representation of dates as returned by Javascript Date.toJSON() method.
-     *
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON
      * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
@@ -295,7 +181,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Compares two Interval objects according to their duration.
+     * Compares two instances according to their duration.
      *
      * Returns:
      * <ul>
@@ -363,8 +249,6 @@ final class Period implements JsonSerializable
     /**
      * Tells whether a Interval is entirely after the specified index.
      * The index can be a DateTimeInterface object or another Interval object.
-     *
-     * @param Period|DateTimeInterface $index
      */
     public function isAfter($index): bool
     {
@@ -378,8 +262,6 @@ final class Period implements JsonSerializable
     /**
      * Tells whether a Interval is entirely before the specified index.
      * The index can be a DateTimeInterface object or another Interval object.
-     *
-     * @param Period|DateTimeInterface $index
      */
     public function isBefore($index): bool
     {
@@ -393,8 +275,6 @@ final class Period implements JsonSerializable
     /**
      * Tells whether the specified index is fully contained within
      * the current Period object.
-     *
-     * @param Period|DateTimeInterface $index
      */
     public function contains($index): bool
     {
@@ -484,7 +364,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Computes the intersection between two Interval objects.
+     * Computes the intersection between two instances.
      *
      * @throws Exception If both objects do not overlaps
      */
@@ -501,7 +381,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Computes the gap between two Interval objects.
+     * Computes the gap between two instances.
      *
      * @throws Exception If both objects overlaps
      */
@@ -519,7 +399,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Computes the difference between two overlapsing Interval objects.
+     * Computes the difference between two overlapsing instances.
      *
      * This method is not part of the Interval.
      *
@@ -677,7 +557,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Returns the difference between two Interval objects expressed in seconds.
+     * Returns the difference between two instances expressed in seconds.
      */
     public function timestampIntervalDiff(Period $interval): float
     {
@@ -685,7 +565,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Returns the difference between two Interval objects expressed in DateInterval.
+     * Returns the difference between two instances expressed in DateInterval.
      */
     public function dateIntervalDiff(Period $interval): DateInterval
     {
@@ -693,7 +573,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Merges one or more Interval objects to return a new instance.
+     * Merges one or more instances to return a new instance.
      * The resulting instance represents the largest duration possible.
      *
      * @param Period ...$intervals

--- a/src/Period.php
+++ b/src/Period.php
@@ -58,7 +58,7 @@ final class Period implements JsonSerializable
      *                   recurrences instead of a end datepoint.
      *                   https://secure.php.net/manual/en/dateperiod.getenddate.php
      */
-    public static function createFromDatePeriod(DatePeriod $datePeriod): self
+    public static function fromDatePeriod(DatePeriod $datePeriod): self
     {
         $endDate = $datePeriod->getEndDate();
         if ($endDate instanceof DateTimeInterface) {

--- a/src/Period.php
+++ b/src/Period.php
@@ -190,9 +190,17 @@ final class Period implements JsonSerializable
      * <li>  0 if both Interval objects have the same duration</li>
      * </ul>
      */
-    public function compareDuration(Period $interval): int
+    public function durationCompare(Period $interval): int
     {
         return $this->endDate <=> $this->startDate->add($interval->getDateInterval());
+    }
+
+    /**
+     * Tells whether the current instance duration is equal to the submitted one.
+     */
+    public function durationEquals(Period $interval): bool
+    {
+        return 0 === $this->durationCompare($interval);
     }
 
     /**
@@ -200,7 +208,7 @@ final class Period implements JsonSerializable
      */
     public function durationGreaterThan(Period $interval): bool
     {
-        return 1 === $this->compareDuration($interval);
+        return 1 === $this->durationCompare($interval);
     }
 
     /**
@@ -208,15 +216,7 @@ final class Period implements JsonSerializable
      */
     public function durationLessThan(Period $interval): bool
     {
-        return -1 === $this->compareDuration($interval);
-    }
-
-    /**
-     * Tells whether the current instance duration is equal to the submitted one.
-     */
-    public function sameDurationAs(Period $interval): bool
-    {
-        return 0 === $this->compareDuration($interval);
+        return -1 === $this->durationCompare($interval);
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -24,6 +24,7 @@ use const FILTER_VALIDATE_INT;
 use function filter_var;
 use function get_class;
 use function gettype;
+use function intdiv;
 use function is_object;
 use function is_string;
 use function sprintf;

--- a/src/functions.php
+++ b/src/functions.php
@@ -119,13 +119,13 @@ function interval_before($endDate, $duration): Period
 function year($int_or_datepoint): Period
 {
     if (is_int($int_or_datepoint)) {
-        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setDate($int_or_datepoint, 1, 1);
+        $startDate = (new DateTimeImmutable())->setTime(0, 0)->setDate($int_or_datepoint, 1, 1);
 
         return new Period($startDate, $startDate->add(new DateInterval('P1Y')));
     }
 
     $datepoint = datepoint($int_or_datepoint);
-    $startDate = $datepoint->setTime(0, 0, 0, 0)->setDate((int) $datepoint->format('Y'), 1, 1);
+    $startDate = $datepoint->setTime(0, 0)->setDate((int) $datepoint->format('Y'), 1, 1);
 
     return new Period($startDate, $startDate->add(new DateInterval('P1Y')));
 }
@@ -138,20 +138,20 @@ function year($int_or_datepoint): Period
 function iso_year($int_or_datepoint): Period
 {
     if (is_int($int_or_datepoint)) {
-        $datepoint = (new DateTimeImmutable())->setTime(0, 0, 0, 0);
+        $datepoint = (new DateTimeImmutable())->setTime(0, 0);
 
         return new Period(
-            $datepoint->setISODate($int_or_datepoint, 1, 1),
-            $datepoint->setISODate(++$int_or_datepoint, 1, 1)
+            $datepoint->setISODate($int_or_datepoint, 1),
+            $datepoint->setISODate(++$int_or_datepoint, 1)
         );
     }
 
-    $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
+    $datepoint = datepoint($int_or_datepoint)->setTime(0, 0);
     $int_or_datepoint = (int) $datepoint->format('o');
 
     return new Period(
-        $datepoint->setISODate($int_or_datepoint, 1, 1),
-        $datepoint->setISODate(++$int_or_datepoint, 1, 1)
+        $datepoint->setISODate($int_or_datepoint, 1),
+        $datepoint->setISODate(++$int_or_datepoint, 1)
     );
 }
 
@@ -165,7 +165,7 @@ function semester($int_or_datepoint, int $index = null): Period
 {
     if (!is_int($int_or_datepoint)) {
         $datepoint = datepoint($int_or_datepoint);
-        $startDate = $datepoint->setTime(0, 0, 0, 0)->setDate(
+        $startDate = $datepoint->setTime(0, 0)->setDate(
             (int) $datepoint->format('Y'),
             (intdiv((int) $datepoint->format('n'), 6) * 6) + 1,
             1
@@ -175,7 +175,7 @@ function semester($int_or_datepoint, int $index = null): Period
     }
 
     if (null !== $index && 0 < $index && 2 >= $index) {
-        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)
+        $startDate = (new DateTimeImmutable())->setTime(0, 0)
             ->setDate($int_or_datepoint, (($index - 1) * 6) + 1, 1);
 
         return new Period($startDate, $startDate->add(new DateInterval('P6M')));
@@ -193,7 +193,7 @@ function semester($int_or_datepoint, int $index = null): Period
 function quarter($int_or_datepoint, int $index = null): Period
 {
     if (!is_int($int_or_datepoint)) {
-        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
+        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0);
         $startDate = $datepoint->setDate(
             (int) $datepoint->format('Y'),
             (intdiv((int) $datepoint->format('n'), 3) * 3) + 1,
@@ -204,7 +204,7 @@ function quarter($int_or_datepoint, int $index = null): Period
     }
 
     if (null !== $index && 0 < $index && 4 >= $index) {
-        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)
+        $startDate = (new DateTimeImmutable())->setTime(0, 0)
             ->setDate($int_or_datepoint, (($index - 1) * 3) + 1, 1);
 
         return new Period($startDate, $startDate->add(new DateInterval('P3M')));
@@ -222,14 +222,14 @@ function quarter($int_or_datepoint, int $index = null): Period
 function month($int_or_datepoint, int $index = null): Period
 {
     if (!is_int($int_or_datepoint)) {
-        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
+        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0);
         $startDate = $datepoint->setDate((int) $datepoint->format('Y'), (int) $datepoint->format('n'), 1);
 
         return new Period($startDate, $startDate->add(new DateInterval('P1M')));
     }
 
     if (null !== $index && 0 < $index && 12 >= $index) {
-        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setDate($int_or_datepoint, $index, 1);
+        $startDate = (new DateTimeImmutable())->setTime(0, 0)->setDate($int_or_datepoint, $index, 1);
 
         return new Period($startDate, $startDate->add(new DateInterval('P1M')));
     }
@@ -246,14 +246,14 @@ function month($int_or_datepoint, int $index = null): Period
 function iso_week($int_or_datepoint, int $index = null): Period
 {
     if (!is_int($int_or_datepoint)) {
-        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
+        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0);
         $startDate = $datepoint->setISODate((int) $datepoint->format('o'), (int) $datepoint->format('W'), 1);
 
         return new Period($startDate, $startDate->add(new DateInterval('P7D')));
     }
 
     if (null !== $index && 0 < $index && 53 >= $index) {
-        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setISODate($int_or_datepoint, $index, 1);
+        $startDate = (new DateTimeImmutable())->setTime(0, 0)->setISODate($int_or_datepoint, $index, 1);
 
         return new Period($startDate, $startDate->add(new DateInterval('P7D')));
     }
@@ -269,7 +269,7 @@ function iso_week($int_or_datepoint, int $index = null): Period
  */
 function day($datepoint): Period
 {
-    $startDate = datepoint($datepoint)->setTime(0, 0, 0, 0);
+    $startDate = datepoint($datepoint)->setTime(0, 0);
 
     return new Period($startDate, $startDate->add(new DateInterval('P1D')));
 }
@@ -283,7 +283,7 @@ function day($datepoint): Period
 function hour($datepoint): Period
 {
     $datepoint = datepoint($datepoint);
-    $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0, 0, 0);
+    $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0);
 
     return new Period($startDate, $startDate->add(new DateInterval('PT1H')));
 }
@@ -297,7 +297,7 @@ function hour($datepoint): Period
 function minute($datepoint): Period
 {
     $datepoint = datepoint($datepoint);
-    $startDate = $datepoint->setTime((int) $datepoint->format('H'), (int) $datepoint->format('i'), 0, 0);
+    $startDate = $datepoint->setTime((int) $datepoint->format('H'), (int) $datepoint->format('i'));
 
     return new Period($startDate, $startDate->add(new DateInterval('PT1M')));
 }
@@ -314,8 +314,7 @@ function second($datepoint): Period
     $startDate = $datepoint->setTime(
         (int) $datepoint->format('H'),
         (int) $datepoint->format('i'),
-        (int) $datepoint->format('s'),
-        0
+        (int) $datepoint->format('s')
     );
 
     return new Period($startDate, $startDate->add(new DateInterval('PT1S')));

--- a/src/functions.php
+++ b/src/functions.php
@@ -89,3 +89,243 @@ function duration($duration): DateInterval
         is_object($duration) ? get_class($duration) : gettype($duration)
     ));
 }
+
+/**
+ * Creates new instance from a starting point and an interval.
+ */
+function interval_after($startDate, $duration): Period
+{
+    $startDate = datepoint($startDate);
+
+    return new Period($startDate, $startDate->add(duration($duration)));
+}
+
+/**
+ * Creates new instance from a ending excluded datepoint and an interval.
+ */
+function interval_before($endDate, $duration): Period
+{
+    $endDate = datepoint($endDate);
+
+    return new Period($endDate->sub(duration($duration)), $endDate);
+}
+
+/**
+ * Creates new instance for a specific year.
+ *
+ * @param mixed $int_or_datepoint a year as an int or a datepoint
+ */
+function year($int_or_datepoint): Period
+{
+    if (is_int($int_or_datepoint)) {
+        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setDate($int_or_datepoint, 1, 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P1Y')));
+    }
+
+    $datepoint = datepoint($int_or_datepoint);
+    $startDate = $datepoint->setTime(0, 0, 0, 0)->setDate((int) $datepoint->format('Y'), 1, 1);
+
+    return new Period($startDate, $startDate->add(new DateInterval('P1Y')));
+}
+
+/**
+ * Creates new instance for a specific ISO year.
+ *
+ * @param mixed $int_or_datepoint a year as an int or a datepoint
+ */
+function iso_year($int_or_datepoint): Period
+{
+    if (is_int($int_or_datepoint)) {
+        $datepoint = (new DateTimeImmutable())->setTime(0, 0, 0, 0);
+
+        return new Period(
+            $datepoint->setISODate($int_or_datepoint, 1, 1),
+            $datepoint->setISODate(++$int_or_datepoint, 1, 1)
+        );
+    }
+
+    $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
+    $int_or_datepoint = (int) $datepoint->format('o');
+
+    return new Period(
+        $datepoint->setISODate($int_or_datepoint, 1, 1),
+        $datepoint->setISODate(++$int_or_datepoint, 1, 1)
+    );
+}
+
+/**
+ * Creates new instance for a specific semester in a given year.
+ *
+ * @param mixed    $int_or_datepoint a year as an int or a datepoint
+ * @param null|int $index            a semester index from 1 to 2 included
+ */
+function semester($int_or_datepoint, int $index = null): Period
+{
+    if (!is_int($int_or_datepoint)) {
+        $datepoint = datepoint($int_or_datepoint);
+        $startDate = $datepoint->setTime(0, 0, 0, 0)->setDate(
+            (int) $datepoint->format('Y'),
+            (intdiv((int) $datepoint->format('n'), 6) * 6) + 1,
+            1
+        );
+
+        return new Period($startDate, $startDate->add(new DateInterval('P6M')));
+    }
+
+    if (null !== $index && 0 < $index && 2 >= $index) {
+        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)
+            ->setDate($int_or_datepoint, (($index - 1) * 6) + 1, 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P6M')));
+    }
+
+    throw new Exception('The semester index is not contained within the valid range.');
+}
+
+/**
+ * Creates new instance for a specific quarter in a given year.
+ *
+ * @param mixed    $int_or_datepoint a year as an int or a datepoint
+ * @param null|int $index            quarter index from 1 to 4 included
+ */
+function quarter($int_or_datepoint, int $index = null): Period
+{
+    if (!is_int($int_or_datepoint)) {
+        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
+        $startDate = $datepoint->setDate(
+            (int) $datepoint->format('Y'),
+            (intdiv((int) $datepoint->format('n'), 3) * 3) + 1,
+            1
+        );
+
+        return new Period($startDate, $startDate->add(new DateInterval('P3M')));
+    }
+
+    if (null !== $index && 0 < $index && 4 >= $index) {
+        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)
+            ->setDate($int_or_datepoint, (($index - 1) * 3) + 1, 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P3M')));
+    }
+
+    throw new Exception('The quarter index is not contained within the valid range.');
+}
+
+/**
+ * Creates new instance for a specific year and month.
+ *
+ * @param mixed    $int_or_datepoint a year as an int or a datepoint
+ * @param int|null $index            month index from 1 to 12 included
+ */
+function month($int_or_datepoint, int $index = null): Period
+{
+    if (!is_int($int_or_datepoint)) {
+        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
+        $startDate = $datepoint->setDate((int) $datepoint->format('Y'), (int) $datepoint->format('n'), 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P1M')));
+    }
+
+    if (null !== $index && 0 < $index && 12 >= $index) {
+        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setDate($int_or_datepoint, $index, 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P1M')));
+    }
+
+    throw new Exception('The month index is not contained within the valid range.');
+}
+
+/**
+ * Creates new instance for a specific ISO8601 week.
+ *
+ * @param mixed    $int_or_datepoint a year as an int or a datepoint
+ * @param int|null $index            index from 1 to 53 included
+ */
+function iso_week($int_or_datepoint, int $index = null): Period
+{
+    if (!is_int($int_or_datepoint)) {
+        $datepoint = datepoint($int_or_datepoint)->setTime(0, 0, 0, 0);
+        $startDate = $datepoint->setISODate((int) $datepoint->format('o'), (int) $datepoint->format('W'), 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P7D')));
+    }
+
+    if (null !== $index && 0 < $index && 53 >= $index) {
+        $startDate = (new DateTimeImmutable())->setTime(0, 0, 0, 0)->setISODate($int_or_datepoint, $index, 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P7D')));
+    }
+
+    throw new Exception('The week index is not contained within the valid range.');
+}
+
+/**
+ * Creates new instance for a specific date.
+ *
+ * The date is truncated so that the time range starts at midnight
+ * according to the date timezone and last a full day.
+ */
+function day($datepoint): Period
+{
+    $startDate = datepoint($datepoint)->setTime(0, 0, 0, 0);
+
+    return new Period($startDate, $startDate->add(new DateInterval('P1D')));
+}
+
+/**
+ * Creates new instance for a specific date and hour.
+ *
+ * The starting datepoint represents the beginning of the hour
+ * The interval is equal to 1 hour
+ */
+function hour($datepoint): Period
+{
+    $datepoint = datepoint($datepoint);
+    $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0, 0, 0);
+
+    return new Period($startDate, $startDate->add(new DateInterval('PT1H')));
+}
+
+/**
+ * Creates new instance for a specific date, hour and minute.
+ *
+ * The starting datepoint represents the beginning of the minute
+ * The interval is equal to 1 minute
+ */
+function minute($datepoint): Period
+{
+    $datepoint = datepoint($datepoint);
+    $startDate = $datepoint->setTime((int) $datepoint->format('H'), (int) $datepoint->format('i'), 0, 0);
+
+    return new Period($startDate, $startDate->add(new DateInterval('PT1M')));
+}
+
+/**
+ * Creates new instance for a specific date, hour, minute and second.
+ *
+ * The starting datepoint represents the beginning of the second
+ * The interval is equal to 1 second
+ */
+function second($datepoint): Period
+{
+    $datepoint = datepoint($datepoint);
+    $startDate = $datepoint->setTime(
+        (int) $datepoint->format('H'),
+        (int) $datepoint->format('i'),
+        (int) $datepoint->format('s'),
+        0
+    );
+
+    return new Period($startDate, $startDate->add(new DateInterval('PT1S')));
+}
+
+/**
+ * Creates new instance for a specific datepoint.
+ */
+function instant($datepoint): Period
+{
+    $datepoint = datepoint($datepoint);
+
+    return new Period($datepoint, $datepoint);
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -112,6 +112,18 @@ function interval_before($endDate, $duration): Period
 }
 
 /**
+ * Creates new instance where the given duration is simultaneously
+ * substracted from and added to the datepoint.
+ */
+function interval_around($datepoint, $duration): Period
+{
+    $datepoint = datepoint($datepoint);
+    $duration = duration($duration);
+
+    return new Period($datepoint->sub($duration), $datepoint->add($duration));
+}
+
+/**
  * Creates new instance for a specific year.
  *
  * @param mixed $int_or_datepoint a year as an int or a datepoint

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -27,6 +27,7 @@ use function League\Period\duration;
 use function League\Period\hour;
 use function League\Period\instant;
 use function League\Period\interval_after;
+use function League\Period\interval_around;
 use function League\Period\interval_before;
 use function League\Period\iso_week;
 use function League\Period\iso_year;
@@ -191,6 +192,23 @@ class FunctionTest extends TestCase
     {
         self::expectException(Exception::class);
         interval_before(new DateTime('2012-01-12'), '-1 DAY');
+    }
+
+    public function testIntervalAround()
+    {
+        $date = '2012-06-05';
+        $duration = '1 WEEK';
+
+        $period = interval_around($date, $duration);
+        self::assertTrue($period->contains($date));
+        self::assertEquals(datepoint($date)->sub(duration($duration)), $period->getStartDate());
+        self::assertEquals(datepoint($date)->add(duration($duration)), $period->getEndDate());
+    }
+
+    public function testIntervalAroundThrowsException()
+    {
+        self::expectException(Exception::class);
+        interval_around(new DateTime('2012-06-05'), '-1 DAY');
     }
 
     public function testISOWeek()

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -114,16 +114,16 @@ class FunctionTest extends TestCase
     }
 
     /**
-     * @dataProvider provideCreateFromDurationData
+     * @dataProvider provideIntervalAfterData
      */
-    public function testcreateFromDurationAfterStart($startDate, $endDate, $duration)
+    public function testIntervalAfter($startDate, $endDate, $duration)
     {
         $period = interval_after($startDate, $duration);
         self::assertEquals(new DateTimeImmutable($startDate), $period->getStartDate());
         self::assertEquals(new DateTimeImmutable($endDate), $period->getEndDate());
     }
 
-    public function provideCreateFromDurationData()
+    public function provideIntervalAfterData()
     {
         return [
             'usingAString' => [
@@ -144,35 +144,35 @@ class FunctionTest extends TestCase
         ];
     }
 
-    public function testCreateFromDurationWithInvalidInteger()
+    public function testIntervalAfterWithInvalidInteger()
     {
         self::expectException(PhpException::class);
         interval_after('2014-01-01', -1);
     }
 
-    public function testCreateFromDurationFailedWithOutofRangeInterval()
+    public function testIntervalAfterFailedWithOutofRangeInterval()
     {
         self::expectException(Exception::class);
         interval_after(new DateTime('2012-01-12'), '-1 DAY');
     }
 
-    public function testCreateFromDurationFailedWithInvalidInterval()
+    public function testIntervalAfterFailedWithInvalidInterval()
     {
         self::expectException(TypeError::class);
         interval_after(new DateTime('2012-01-12'), []);
     }
 
     /**
-     * @dataProvider provideCreateFromDurationBeforeEndData
+     * @dataProvider intervalBeforeProviderData
      */
-    public function testCreateFromDurationBeforeEnd($startDate, $endDate, $duration)
+    public function testIntervalBefore($startDate, $endDate, $duration)
     {
         $period = interval_before($endDate, $duration);
         self::assertEquals(new DateTimeImmutable($startDate), $period->getStartDate());
         self::assertEquals(new DateTimeImmutable($endDate), $period->getEndDate());
     }
 
-    public function provideCreateFromDurationBeforeEndData()
+    public function intervalBeforeProviderData()
     {
         return [
             'usingAString' => [
@@ -187,144 +187,144 @@ class FunctionTest extends TestCase
         ];
     }
 
-    public function testCreateFromDurationBeforeEndFailedWithOutofRangeInterval()
+    public function testIntervalBeforeFailedWithOutofRangeInterval()
     {
         self::expectException(Exception::class);
         interval_before(new DateTime('2012-01-12'), '-1 DAY');
     }
 
-    public function testcreateFromISOWeek()
+    public function testISOWeek()
     {
         $period = iso_week(2014, 3);
         self::assertEquals(new DateTimeImmutable('2014-01-13'), $period->getStartDate());
         self::assertEquals(new DateTimeImmutable('2014-01-20'), $period->getEndDate());
     }
 
-    public function testcreateFromISOWeekFailedWithLowInvalidIndex()
+    public function testISOWeekFailedWithLowInvalidIndex()
     {
         self::expectException(Exception::class);
         iso_week(2014, 0);
     }
 
-    public function testcreateFromISOWeekFailedWithHighInvalidIndex()
+    public function testISOWeekFailedWithHighInvalidIndex()
     {
         self::expectException(Exception::class);
         iso_week(2014, 54);
     }
 
-    public function testcreateFromISOWeekFailedWithInvalidYearIndex()
+    public function testISOWeekFailedWithInvalidYearIndex()
     {
         self::expectException(TypeError::class);
         iso_week([], 1);
     }
 
-    public function testcreateFromISOWeekFailedWithMissingSemesterValue()
+    public function testISOWeekFailedWithMissingSemesterValue()
     {
         self::expectException(Exception::class);
         iso_week(2014, null);
     }
 
-    public function testCreateFromMonth()
+    public function testMonth()
     {
         $period = month(2014, 3);
         self::assertEquals(new DateTimeImmutable('2014-03-01'), $period->getStartDate());
         self::assertEquals(new DateTimeImmutable('2014-04-01'), $period->getEndDate());
     }
 
-    public function testCreateFromMonthFailedWithHighInvalidIndex()
+    public function testMonthFailedWithHighInvalidIndex()
     {
         self::expectException(Exception::class);
         month(2014, 13);
     }
 
-    public function testCreateFromMonthFailedWithLowInvalidIndex()
+    public function testMonthFailedWithLowInvalidIndex()
     {
         self::expectException(Exception::class);
         month(2014, 0);
     }
 
-    public function testCreateFromMonthFailedWithInvalidYearIndex()
+    public function testMonthFailedWithInvalidYearIndex()
     {
         self::expectException(TypeError::class);
         month([], 1);
     }
 
-    public function testCreateFromMonthFailedWithMissingSemesterValue()
+    public function testMonthFailedWithMissingSemesterValue()
     {
         self::expectException(Exception::class);
         month(2014, null);
     }
 
-    public function testCreateFromQuarter()
+    public function testQuarter()
     {
         $period = quarter(2014, 3);
         self::assertEquals(new DateTimeImmutable('2014-07-01'), $period->getStartDate());
         self::assertEquals(new DateTimeImmutable('2014-10-01'), $period->getEndDate());
     }
 
-    public function testCreateFromQuarterFailedWithHighInvalidIndex()
+    public function testQuarterFailedWithHighInvalidIndex()
     {
         self::expectException(Exception::class);
         quarter(2014, 5);
     }
 
-    public function testCreateFromQuarterFailedWithLowInvalidIndex()
+    public function testQuarterFailedWithLowInvalidIndex()
     {
         self::expectException(Exception::class);
         quarter(2014, 0);
     }
 
-    public function testCreateFromQuarterFailedWithInvalidYearIndex()
+    public function testQuarterFailedWithInvalidYearIndex()
     {
         self::expectException(TypeError::class);
         quarter([], 1);
     }
 
-    public function testCreateFromQuarterFailedWithMissingSemesterValue()
+    public function testQuarterFailedWithMissingSemesterValue()
     {
         self::expectException(Exception::class);
         quarter(2014, null);
     }
 
-    public function testCreateFromSemester()
+    public function testSemester()
     {
         $period = semester(2014, 2);
         self::assertEquals(new DateTimeImmutable('2014-07-01'), $period->getStartDate());
         self::assertEquals(new DateTimeImmutable('2015-01-01'), $period->getEndDate());
     }
 
-    public function testCreateFromSemesterFailedWithInvalidYearIndex()
+    public function testSemesterFailedWithInvalidYearIndex()
     {
         self::expectException(TypeError::class);
         semester([], 1);
     }
 
-    public function testCreateFromSemesterFailedWithMissingSemesterValue()
+    public function testSemesterFailedWithMissingSemesterValue()
     {
         self::expectException(Exception::class);
         semester(2014, null);
     }
 
-    public function testCreateFromSemesterFailedWithLowInvalidIndex()
+    public function testSemesterFailedWithLowInvalidIndex()
     {
         self::expectException(Exception::class);
         semester(2014, 0);
     }
 
-    public function testCreateFromSemesterFailedWithHighInvalidIndex()
+    public function testSemesterFailedWithHighInvalidIndex()
     {
         self::expectException(Exception::class);
         semester(2014, 3);
     }
 
-    public function testCreateFromYear()
+    public function testYear()
     {
         $period = year(2014);
         self::assertEquals(new DateTimeImmutable('2014-01-01'), $period->getStartDate());
         self::assertEquals(new DateTimeImmutable('2015-01-01'), $period->getEndDate());
     }
 
-    public function testCreateFromISOYear()
+    public function testISOYear()
     {
         $period = iso_year(2014);
         $interval = iso_year('2014-06-25');
@@ -333,7 +333,7 @@ class FunctionTest extends TestCase
         self::assertTrue($period->equals($interval));
     }
 
-    public function testCreateFromDay()
+    public function testDay()
     {
         $period = day(new ExtendedDate('2008-07-01T22:35:17.123456+08:00'));
         self::assertEquals(new DateTimeImmutable('2008-07-01T00:00:00+08:00'), $period->getStartDate());
@@ -344,7 +344,7 @@ class FunctionTest extends TestCase
         self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
-    public function testCreateFromHour()
+    public function testHour()
     {
         $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
         $period = hour($today);
@@ -356,7 +356,7 @@ class FunctionTest extends TestCase
         self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
-    public function testCreateFromMinute()
+    public function testMinute()
     {
         $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
         $period = minute($today);
@@ -368,7 +368,7 @@ class FunctionTest extends TestCase
         self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
-    public function testCreateFromSecond()
+    public function testSecond()
     {
         $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
         $period = second($today);
@@ -381,7 +381,7 @@ class FunctionTest extends TestCase
     }
 
 
-    public function testcreateFromDatepoint()
+    public function testInstant()
     {
         $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
         $period = instant($today);
@@ -403,7 +403,7 @@ class FunctionTest extends TestCase
         self::assertTrue(year('2008-01')->equals(year(2008)));
     }
 
-    public function testCreateFromMonthWithDateTimeInterface()
+    public function testMonthWithDateTimeInterface()
     {
         $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
         $period = month($today);
@@ -415,7 +415,7 @@ class FunctionTest extends TestCase
         self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
-    public function testCreateFromYearWithDateTimeInterface()
+    public function testYearWithDateTimeInterface()
     {
         $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
         $period = year($today);

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -17,10 +17,25 @@ namespace LeagueTest\Period;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Exception as PhpException;
+use League\Period\Exception;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 use function League\Period\datepoint;
+use function League\Period\day;
 use function League\Period\duration;
+use function League\Period\hour;
+use function League\Period\instant;
+use function League\Period\interval_after;
+use function League\Period\interval_before;
+use function League\Period\iso_week;
+use function League\Period\iso_year;
+use function League\Period\minute;
+use function League\Period\month;
+use function League\Period\quarter;
+use function League\Period\second;
+use function League\Period\semester;
+use function League\Period\year;
 
 class FunctionTest extends TestCase
 {
@@ -96,5 +111,319 @@ class FunctionTest extends TestCase
     {
         self::expectException(TypeError::class);
         duration([]);
+    }
+
+    /**
+     * @dataProvider provideCreateFromDurationData
+     */
+    public function testcreateFromDurationAfterStart($startDate, $endDate, $duration)
+    {
+        $period = interval_after($startDate, $duration);
+        self::assertEquals(new DateTimeImmutable($startDate), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable($endDate), $period->getEndDate());
+    }
+
+    public function provideCreateFromDurationData()
+    {
+        return [
+            'usingAString' => [
+                '2015-01-01', '2015-01-02', '+1 DAY',
+            ],
+            'usingAnInt' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', 3600,
+            ],
+            'usingADateInterval' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', new DateInterval('PT1H'),
+            ],
+            'usingAFloatWithNoMicroseconds' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', 3600.0,
+            ],
+            'usingAnInterval' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', hour('2012-01-03 12:00:00'),
+            ],
+        ];
+    }
+
+    public function testCreateFromDurationWithInvalidInteger()
+    {
+        self::expectException(PhpException::class);
+        interval_after('2014-01-01', -1);
+    }
+
+    public function testCreateFromDurationFailedWithOutofRangeInterval()
+    {
+        self::expectException(Exception::class);
+        interval_after(new DateTime('2012-01-12'), '-1 DAY');
+    }
+
+    public function testCreateFromDurationFailedWithInvalidInterval()
+    {
+        self::expectException(TypeError::class);
+        interval_after(new DateTime('2012-01-12'), []);
+    }
+
+    /**
+     * @dataProvider provideCreateFromDurationBeforeEndData
+     */
+    public function testCreateFromDurationBeforeEnd($startDate, $endDate, $duration)
+    {
+        $period = interval_before($endDate, $duration);
+        self::assertEquals(new DateTimeImmutable($startDate), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable($endDate), $period->getEndDate());
+    }
+
+    public function provideCreateFromDurationBeforeEndData()
+    {
+        return [
+            'usingAString' => [
+                '2015-01-01', '2015-01-02', '+1 DAY',
+            ],
+            'usingAnInt' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', 3600,
+            ],
+            'usingADateInterval' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', new DateInterval('PT1H'),
+            ],
+        ];
+    }
+
+    public function testCreateFromDurationBeforeEndFailedWithOutofRangeInterval()
+    {
+        self::expectException(Exception::class);
+        interval_before(new DateTime('2012-01-12'), '-1 DAY');
+    }
+
+    public function testcreateFromISOWeek()
+    {
+        $period = iso_week(2014, 3);
+        self::assertEquals(new DateTimeImmutable('2014-01-13'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-01-20'), $period->getEndDate());
+    }
+
+    public function testcreateFromISOWeekFailedWithLowInvalidIndex()
+    {
+        self::expectException(Exception::class);
+        iso_week(2014, 0);
+    }
+
+    public function testcreateFromISOWeekFailedWithHighInvalidIndex()
+    {
+        self::expectException(Exception::class);
+        iso_week(2014, 54);
+    }
+
+    public function testcreateFromISOWeekFailedWithInvalidYearIndex()
+    {
+        self::expectException(TypeError::class);
+        iso_week([], 1);
+    }
+
+    public function testcreateFromISOWeekFailedWithMissingSemesterValue()
+    {
+        self::expectException(Exception::class);
+        iso_week(2014, null);
+    }
+
+    public function testCreateFromMonth()
+    {
+        $period = month(2014, 3);
+        self::assertEquals(new DateTimeImmutable('2014-03-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-04-01'), $period->getEndDate());
+    }
+
+    public function testCreateFromMonthFailedWithHighInvalidIndex()
+    {
+        self::expectException(Exception::class);
+        month(2014, 13);
+    }
+
+    public function testCreateFromMonthFailedWithLowInvalidIndex()
+    {
+        self::expectException(Exception::class);
+        month(2014, 0);
+    }
+
+    public function testCreateFromMonthFailedWithInvalidYearIndex()
+    {
+        self::expectException(TypeError::class);
+        month([], 1);
+    }
+
+    public function testCreateFromMonthFailedWithMissingSemesterValue()
+    {
+        self::expectException(Exception::class);
+        month(2014, null);
+    }
+
+    public function testCreateFromQuarter()
+    {
+        $period = quarter(2014, 3);
+        self::assertEquals(new DateTimeImmutable('2014-07-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-10-01'), $period->getEndDate());
+    }
+
+    public function testCreateFromQuarterFailedWithHighInvalidIndex()
+    {
+        self::expectException(Exception::class);
+        quarter(2014, 5);
+    }
+
+    public function testCreateFromQuarterFailedWithLowInvalidIndex()
+    {
+        self::expectException(Exception::class);
+        quarter(2014, 0);
+    }
+
+    public function testCreateFromQuarterFailedWithInvalidYearIndex()
+    {
+        self::expectException(TypeError::class);
+        quarter([], 1);
+    }
+
+    public function testCreateFromQuarterFailedWithMissingSemesterValue()
+    {
+        self::expectException(Exception::class);
+        quarter(2014, null);
+    }
+
+    public function testCreateFromSemester()
+    {
+        $period = semester(2014, 2);
+        self::assertEquals(new DateTimeImmutable('2014-07-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2015-01-01'), $period->getEndDate());
+    }
+
+    public function testCreateFromSemesterFailedWithInvalidYearIndex()
+    {
+        self::expectException(TypeError::class);
+        semester([], 1);
+    }
+
+    public function testCreateFromSemesterFailedWithMissingSemesterValue()
+    {
+        self::expectException(Exception::class);
+        semester(2014, null);
+    }
+
+    public function testCreateFromSemesterFailedWithLowInvalidIndex()
+    {
+        self::expectException(Exception::class);
+        semester(2014, 0);
+    }
+
+    public function testCreateFromSemesterFailedWithHighInvalidIndex()
+    {
+        self::expectException(Exception::class);
+        semester(2014, 3);
+    }
+
+    public function testCreateFromYear()
+    {
+        $period = year(2014);
+        self::assertEquals(new DateTimeImmutable('2014-01-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2015-01-01'), $period->getEndDate());
+    }
+
+    public function testCreateFromISOYear()
+    {
+        $period = iso_year(2014);
+        $interval = iso_year('2014-06-25');
+        self::assertEquals(new DateTimeImmutable('2013-12-30'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-12-29'), $period->getEndDate());
+        self::assertTrue($period->equals($interval));
+    }
+
+    public function testCreateFromDay()
+    {
+        $period = day(new ExtendedDate('2008-07-01T22:35:17.123456+08:00'));
+        self::assertEquals(new DateTimeImmutable('2008-07-01T00:00:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2008-07-02T00:00:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
+        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
+    }
+
+    public function testCreateFromHour()
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = hour($today);
+        self::assertEquals(new DateTimeImmutable('2008-07-01T22:00:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2008-07-01T23:00:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
+        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
+    }
+
+    public function testCreateFromMinute()
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = minute($today);
+        self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2008-07-01T22:36:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
+        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
+    }
+
+    public function testCreateFromSecond()
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = second($today);
+        self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:17+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:18+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
+        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
+    }
+
+
+    public function testcreateFromDatepoint()
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = instant($today);
+        self::assertEquals($today, $period->getStartDate());
+        self::assertEquals($today, $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
+        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
+        self::assertEquals(new DateInterval('P0D'), $period->getDateInterval());
+    }
+
+    public function testCreateFromWithDateTimeInterface()
+    {
+        self::assertTrue(iso_week('2008W27')->equals(iso_week(2008, 27)));
+        self::assertTrue(month('2008-07')->equals(month(2008, 7)));
+        self::assertTrue(quarter('2008-02')->equals(quarter(2008, 1)));
+        self::assertTrue(semester('2008-10')->equals(semester(2008, 2)));
+        self::assertTrue(year('2008-01')->equals(year(2008)));
+    }
+
+    public function testCreateFromMonthWithDateTimeInterface()
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = month($today);
+        self::assertEquals(new DateTimeImmutable('2008-07-01T00:00:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2008-08-01T00:00:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
+        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
+    }
+
+    public function testCreateFromYearWithDateTimeInterface()
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = year($today);
+        self::assertEquals(new DateTimeImmutable('2008-01-01T00:00:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2009-01-01T00:00:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
+        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 }

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -372,6 +372,8 @@ class FunctionTest extends TestCase
     {
         $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
         $period = second($today);
+        self::assertTrue($period->contains($today));
+        self::assertTrue($today >= $period->getStartDate());
         self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:17+08:00'), $period->getStartDate());
         self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:18+08:00'), $period->getEndDate());
         self::assertEquals('+08:00', $period->getStartDate()->format('P'));

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -24,7 +24,6 @@ use League\Period\Exception;
 use League\Period\Period;
 use PHPUnit\Framework\TestCase;
 use TypeError;
-use function League\Period\hour;
 
 class PeriodTest extends TestCase
 {
@@ -715,7 +714,7 @@ class PeriodTest extends TestCase
                 '2015-01-01 10:00:00', '2015-01-01 11:00:00', 3600.0,
             ],
             'usingAnInterval' => [
-                '2015-01-01 10:00:00', '2015-01-01 11:00:00', hour('2012-01-03 12:00:00'),
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', new Period('2012-01-03 12:00:00', '2012-01-03 13:00:00'),
             ],
         ];
     }

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -632,7 +632,7 @@ class PeriodTest extends TestCase
             new DateInterval('P1D'),
             new DateTime('2016-05-20T00:00:00Z')
         );
-        $period = Period::createFromDatePeriod($datePeriod);
+        $period = Period::fromDatePeriod($datePeriod);
         self::assertEquals($datePeriod->getStartDate(), $period->getStartDate());
         self::assertEquals($datePeriod->getEndDate(), $period->getEndDate());
     }
@@ -640,7 +640,7 @@ class PeriodTest extends TestCase
     public function testCreateFromDatePeriodThrowsException()
     {
         self::expectException(Exception::class);
-        Period::createFromDatePeriod(new DatePeriod('R4/2012-07-01T00:00:00Z/P7D'));
+        Period::fromDatePeriod(new DatePeriod('R4/2012-07-01T00:00:00Z/P7D'));
     }
 
     public function testConstructorThrowTypeError()

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -24,6 +24,7 @@ use League\Period\Exception;
 use League\Period\Period;
 use PHPUnit\Framework\TestCase;
 use TypeError;
+use function League\Period\hour;
 
 class PeriodTest extends TestCase
 {
@@ -275,14 +276,14 @@ class PeriodTest extends TestCase
     }
 
     /**
-     * @dataProvider provideEqualsToData
+     * @dataProvider provideequalsData
      */
-    public function testEqualsTo(Period  $interval1, Period $interval2, bool $expected)
+    public function testequals(Period  $interval1, Period $interval2, bool $expected)
     {
-        self::assertSame($expected, $interval1->equalsTo($interval2));
+        self::assertSame($expected, $interval1->equals($interval2));
     }
 
-    public function provideEqualsToData()
+    public function provideequalsData()
     {
         return [
             'testSameValueAsReturnsTrue' => [
@@ -325,7 +326,7 @@ class PeriodTest extends TestCase
             $total = $total->endingOn($part->getEndDate());
         }
         self::assertInstanceOf(Period::class, $total);
-        self::assertTrue($total->equalsTo($period));
+        self::assertTrue($total->equals($period));
     }
 
     public function testSplitWithLargeInterval()
@@ -334,7 +335,7 @@ class PeriodTest extends TestCase
         $range = $period->split(new DateInterval('P1Y'));
         foreach ($range as $expectedPeriod) {
             self::assertInstanceOf(Period::class, $expectedPeriod);
-            self::assertTrue($expectedPeriod->equalsTo($period));
+            self::assertTrue($expectedPeriod->equals($period));
         }
     }
 
@@ -483,7 +484,7 @@ class PeriodTest extends TestCase
         self::assertInstanceOf(Period::class, $res);
         self::assertEquals($orig->getEndDate(), $res->getStartDate());
         self::assertEquals($alt->getStartDate(), $res->getEndDate());
-        self::assertTrue($res->equalsTo($alt->gap($orig)));
+        self::assertTrue($res->equals($alt->gap($orig)));
     }
 
     public function testGapThrowsExceptionWithOverlapsInterval()
@@ -523,8 +524,8 @@ class PeriodTest extends TestCase
     {
         $interval = new Period(new DateTime('2016-01-01 15:32:12'), new DateTime('2016-01-15 12:00:01'));
         $moved = $interval->move(new DateInterval('P1D'));
-        self::assertFalse($interval->equalsTo($moved));
-        self::assertTrue($interval->move(new DateInterval('PT0S'))->equalsTo($interval));
+        self::assertFalse($interval->equals($moved));
+        self::assertTrue($interval->move(new DateInterval('PT0S'))->equals($interval));
     }
 
     public function testMoveSupportStringIntervals()
@@ -532,7 +533,7 @@ class PeriodTest extends TestCase
         $interval = new Period(new DateTime('2016-01-01 15:32:12'), new DateTime('2016-01-15 12:00:01'));
         $advanced = $interval->move(DateInterval::createFromDateString('1 DAY'));
         $alt = new Period(new DateTime('2016-01-02 15:32:12'), new DateTime('2016-01-16 12:00:01'));
-        self::assertTrue($alt->equalsTo($advanced));
+        self::assertTrue($alt->equals($advanced));
     }
 
     public function testMoveWithInvertedInterval()
@@ -541,14 +542,14 @@ class PeriodTest extends TestCase
         $alt = new Period(new DateTime('2016-01-02 15:32:12'), new DateTime('2016-01-16 12:00:01'));
         $duration = new DateInterval('P1D');
         $duration->invert = 1;
-        self::assertTrue($orig->equalsTo($alt->move($duration)));
+        self::assertTrue($orig->equals($alt->move($duration)));
     }
 
     public function testMoveWithInvertedStringInterval()
     {
         $orig = new Period(new DateTime('2016-01-01 15:32:12'), new DateTime('2016-01-15 12:00:01'));
         $alt = new Period(new DateTime('2016-01-02 15:32:12'), new DateTime('2016-01-16 12:00:01'));
-        self::assertTrue($orig->equalsTo($alt->move(DateInterval::createFromDateString('-1 DAY'))));
+        self::assertTrue($orig->equals($alt->move(DateInterval::createFromDateString('-1 DAY'))));
     }
 
     public function testDiffThrowsException()
@@ -653,7 +654,7 @@ class PeriodTest extends TestCase
     {
         $period = new Period('2014-05-01', '2014-05-08');
         $generatedPeriod = eval('return '.var_export($period, true).';');
-        self::assertTrue($generatedPeriod->equalsTo($period));
+        self::assertTrue($generatedPeriod->equals($period));
         self::assertEquals($generatedPeriod, $period);
     }
 
@@ -714,7 +715,7 @@ class PeriodTest extends TestCase
                 '2015-01-01 10:00:00', '2015-01-01 11:00:00', 3600.0,
             ],
             'usingAnInterval' => [
-                '2015-01-01 10:00:00', '2015-01-01 11:00:00', Period::createFromHour('2012-01-03 12:00:00'),
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', hour('2012-01-03 12:00:00'),
             ],
         ];
     }
@@ -766,37 +767,6 @@ class PeriodTest extends TestCase
     {
         self::expectException(Exception::class);
         Period::createFromDurationBeforeEnd(new DateTime('2012-01-12'), '-1 DAY');
-    }
-
-    public function testcreateFromISOWeek()
-    {
-        $period = Period::createFromISOWeek(2014, 3);
-        self::assertEquals(new DateTimeImmutable('2014-01-13'), $period->getStartDate());
-        self::assertEquals(new DateTimeImmutable('2014-01-20'), $period->getEndDate());
-    }
-
-    public function testcreateFromISOWeekFailedWithLowInvalidIndex()
-    {
-        self::expectException(Exception::class);
-        Period::createFromISOWeek(2014, 0);
-    }
-
-    public function testcreateFromISOWeekFailedWithHighInvalidIndex()
-    {
-        self::expectException(Exception::class);
-        Period::createFromISOWeek(2014, 54);
-    }
-
-    public function testcreateFromISOWeekFailedWithInvalidYearIndex()
-    {
-        self::expectException(TypeError::class);
-        Period::createFromISOWeek([], 1);
-    }
-
-    public function testcreateFromISOWeekFailedWithMissingSemesterValue()
-    {
-        self::expectException(Exception::class);
-        Period::createFromISOWeek(2014, null);
     }
 
     public function testCreateFromMonth()
@@ -899,15 +869,6 @@ class PeriodTest extends TestCase
         self::assertEquals(new DateTimeImmutable('2015-01-01'), $period->getEndDate());
     }
 
-    public function testCreateFromISOYear()
-    {
-        $period = Period::createFromISOYear(2014);
-        $interval = Period::createFromISOYear('2014-06-25');
-        self::assertEquals(new DateTimeImmutable('2013-12-30'), $period->getStartDate());
-        self::assertEquals(new DateTimeImmutable('2014-12-29'), $period->getEndDate());
-        self::assertTrue($period->equalsTo($interval));
-    }
-
     public function testCreateFromDay()
     {
         $period = Period::createFromDay(new ExtendedDate('2008-07-01T22:35:17.123456+08:00'));
@@ -919,63 +880,12 @@ class PeriodTest extends TestCase
         self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
-    public function testCreateFromHour()
-    {
-        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
-        $period = Period::createFromHour($today);
-        self::assertEquals(new DateTimeImmutable('2008-07-01T22:00:00+08:00'), $period->getStartDate());
-        self::assertEquals(new DateTimeImmutable('2008-07-01T23:00:00+08:00'), $period->getEndDate());
-        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
-        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
-    }
-
-    public function testCreateFromMinute()
-    {
-        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
-        $period = Period::createFromMinute($today);
-        self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:00+08:00'), $period->getStartDate());
-        self::assertEquals(new DateTimeImmutable('2008-07-01T22:36:00+08:00'), $period->getEndDate());
-        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
-        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
-    }
-
-    public function testCreateFromSecond()
-    {
-        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
-        $period = Period::createFromSecond($today);
-        self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:17+08:00'), $period->getStartDate());
-        self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:18+08:00'), $period->getEndDate());
-        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
-        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
-    }
-
-
-    public function testcreateFromDatepoint()
-    {
-        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
-        $period = Period::createFromDatepoint($today);
-        self::assertEquals($today, $period->getStartDate());
-        self::assertEquals($today, $period->getEndDate());
-        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
-        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
-        self::assertEquals(new DateInterval('P0D'), $period->getDateInterval());
-    }
-
     public function testCreateFromWithDateTimeInterface()
     {
-        self::assertTrue(Period::createFromISOWeek('2008W27')->equalsTo(Period::createFromISOWeek(2008, 27)));
-        self::assertTrue(Period::createFromMonth('2008-07')->equalsTo(Period::createFromMonth(2008, 7)));
-        self::assertTrue(Period::createFromQuarter('2008-02')->equalsTo(Period::createFromQuarter(2008, 1)));
-        self::assertTrue(Period::createFromSemester('2008-10')->equalsTo(Period::createFromSemester(2008, 2)));
-        self::assertTrue(Period::createFromYear('2008-01')->equalsTo(Period::createFromYear(2008)));
+        self::assertTrue(Period::createFromMonth('2008-07')->equals(Period::createFromMonth(2008, 7)));
+        self::assertTrue(Period::createFromQuarter('2008-02')->equals(Period::createFromQuarter(2008, 1)));
+        self::assertTrue(Period::createFromSemester('2008-10')->equals(Period::createFromSemester(2008, 2)));
+        self::assertTrue(Period::createFromYear('2008-01')->equals(Period::createFromYear(2008)));
     }
 
     public function testCreateFromMonthWithDateTimeInterface()

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -125,14 +125,14 @@ class PeriodTest extends TestCase
     }
 
     /**
-     * @dataProvider provideAbutsData
+     * @dataProvider abutsDataProvider
      */
     public function testAbuts(Period $interval, Period $arg, $expected)
     {
         self::assertSame($expected, $interval->abuts($arg));
     }
 
-    public function provideAbutsData()
+    public function abutsDataProvider()
     {
         return [
             'testAbutsReturnsTrueWithEqualDatePoints' => [
@@ -149,14 +149,14 @@ class PeriodTest extends TestCase
     }
 
     /**
-     * @dataProvider provideOverlapsData
+     * @dataProvider overlapsDataProvider
      */
     public function testOverlaps(Period $interval, Period $arg, $expected)
     {
         self::assertSame($expected, $interval->overlaps($arg));
     }
 
-    public function provideOverlapsData()
+    public function overlapsDataProvider()
     {
         return [
             'testOverlapsReturnsFalseWithAbutsIntervals' => [
@@ -193,14 +193,14 @@ class PeriodTest extends TestCase
     }
 
     /**
-     * @dataProvider provideContainsData
+     * @dataProvider containsDataProvider
      */
     public function testContains(Period $interval, $arg, $expected)
     {
         self::assertSame($expected, $interval->contains($arg));
     }
 
-    public function provideContainsData()
+    public function containsDataProvider()
     {
         return [
             'testContainsReturnsTrueWithADateTimeInterfaceObject' => [
@@ -247,14 +247,14 @@ class PeriodTest extends TestCase
     }
 
     /**
-     * @dataProvider provideCompareDurationData
+     * @dataProvider durationCompareDataProvider
      */
-    public function testCompareDuration(Period $interval1, Period $interval2, int $expected)
+    public function testdurationCompare(Period $interval1, Period $interval2, int $expected)
     {
-        self::assertSame($expected, $interval1->compareDuration($interval2));
+        self::assertSame($expected, $interval1->durationCompare($interval2));
     }
 
-    public function provideCompareDurationData()
+    public function durationCompareDataProvider()
     {
         return [
             'testDurationLessThan' => [
@@ -267,7 +267,7 @@ class PeriodTest extends TestCase
                 new Period(new DateTime('2012-01-01'), new DateTime('2012-01-07')),
                 1,
             ],
-            'testSameDurationAsReturnsTrueWithMicroseconds' => [
+            'testdurationEqualsReturnsTrueWithMicroseconds' => [
                 new Period(new DateTime('2012-01-01 00:00:00'), new DateTime('2012-01-03 00:00:00')),
                 new Period(new DateTime('2012-02-02 00:00:00'), new DateTime('2012-02-04 00:00:00')),
                 0,
@@ -276,14 +276,14 @@ class PeriodTest extends TestCase
     }
 
     /**
-     * @dataProvider provideequalsData
+     * @dataProvider equalsDataProvider
      */
     public function testequals(Period  $interval1, Period $interval2, bool $expected)
     {
         self::assertSame($expected, $interval1->equals($interval2));
     }
 
-    public function provideequalsData()
+    public function equalsDataProvider()
     {
         return [
             'testSameValueAsReturnsTrue' => [
@@ -689,14 +689,14 @@ class PeriodTest extends TestCase
     }
 
     /**
-     * @dataProvider provideCompareDurationInnerMethodsData
+     * @dataProvider durationCompareInnerMethodsDataProvider
      */
-    public function testCompareDurationInnerMethods(Period $period1, Period $period2, $method, $expected)
+    public function testdurationCompareInnerMethods(Period $period1, Period $period2, $method, $expected)
     {
         self::assertSame($expected, $period1->$method($period2));
     }
 
-    public function provideCompareDurationInnerMethodsData()
+    public function durationCompareInnerMethodsDataProvider()
     {
         return [
             'testDurationLessThan' => [
@@ -711,16 +711,16 @@ class PeriodTest extends TestCase
                 'durationGreaterThan',
                 true,
             ],
-            'testSameDurationAsReturnsTrueWithMicroseconds' => [
+            'testdurationEqualsReturnsTrueWithMicroseconds' => [
                 new Period('2012-01-01 00:00:00', '2012-01-03 00:00:00'),
                 new Period('2012-02-02 00:00:00', '2012-02-04 00:00:00'),
-                'sameDurationAs',
+                'durationEquals',
                 true,
             ],
         ];
     }
 
-    public function testwithDurationAfterStart()
+    public function testWithDurationAfterStart()
     {
         $expected = new Period('2014-03-01', '2014-04-01');
         $period = new Period('2014-03-01', '2014-03-15');
@@ -773,7 +773,7 @@ class PeriodTest extends TestCase
     {
         $orig = interval_after('2012-01-01', '2 MONTH');
         $period = $orig->moveEndDate('-1 MONTH');
-        self::assertSame(1, $orig->compareDuration($period));
+        self::assertSame(1, $orig->durationCompare($period));
         self::assertTrue($orig->durationGreaterThan($period));
         self::assertEquals($orig->getStartDate(), $period->getStartDate());
     }
@@ -788,7 +788,7 @@ class PeriodTest extends TestCase
     {
         $orig = month(2012, 1);
         $period = $orig->moveStartDate('-1 MONTH');
-        self::assertSame(-1, $orig->compareDuration($period));
+        self::assertSame(-1, $orig->durationCompare($period));
         self::assertTrue($orig->durationLessThan($period));
         self::assertEquals($orig->getEndDate(), $period->getEndDate());
         self::assertNotEquals($orig->getStartDate(), $period->getStartDate());
@@ -798,7 +798,7 @@ class PeriodTest extends TestCase
     {
         $orig = month(2012, 1);
         $period = $orig->moveStartDate('2 WEEKS');
-        self::assertSame(1, $orig->compareDuration($period));
+        self::assertSame(1, $orig->durationCompare($period));
         self::assertTrue($orig->durationGreaterThan($period));
         self::assertEquals($orig->getEndDate(), $period->getEndDate());
         self::assertNotEquals($orig->getStartDate(), $period->getStartDate());


### PR DESCRIPTION
## Introduction

To better decouple the Period class and its named constructors. We are adding helper functions and deprecating the class named constructors.

```php
<?php
use League\Period\Period;
use function League\Period\interval_after;

$period = Period::createFromDuration('NOW', '+1 HOUR');
//becomes
$period = interval_after('NOW', '+1 HOUR');
```

## Proposal 

### Describe the new/updated/fixed feature

Adds simple functions in the Period namespace to reduce the use of named constructors.

### Backward Incompatible Changes

on the next major release the named constructors will be marked as deprecated before removal in the next +1 major release

### Targeted release version

next major release (V4.0)

### PR Impact

Deprecate the use of named constructors

## Open issues

- Is it a good idea ?
- should we wait a whole major cycle before removing the named constructor or should we remove them now ?
-  should we introduce them in v3 too to ease migration ?
