### PR TITLE
Re-introduce named constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All Notable changes to `Period` will be documented in this file
 
+## Next - TBD
+
+### Added
+
+- `League\Period\Datepoint`
+- `League\Period\Duration`
+- `Period::fromYear`
+- `Period::fromSemester`
+- `Period::fromQuarter`
+- `Period::fromMonth`
+- `Period::fromDay`
+- `Period::fromHour`
+- `Period::fromMinute`
+- `Period::fromSecond`
+- `Period::fromDatepoint`
+- `Period::fromIsoYear`
+- `Period::fromIsoWeek`
+- `Period::after`
+- `Period::before`
+- `Period::around`
+- `Period::fromDatePeriod`
+- `Period::fromCalendar`
+
+### Fixed
+
+- None
+
+### Deprecated
+
+- `League\Period\datepoint`
+- `League\Period\duration`
+- `League\Period\year`
+- `League\Period\semester`
+- `League\Period\quarter`
+- `League\Period\month`
+- `League\Period\day`
+- `League\Period\hour`
+- `League\Period\minute`
+- `League\Period\second`
+- `League\Period\instant`
+- `League\Period\iso_year`
+- `League\Period\iso_week`
+- `League\Period\interval_after`
+- `League\Period\interval_before`
+- `League\Period\interval_around`
+- `League\Period\interval_from_dateperiod`
+
+### Removed
+
+- None
+
 ## 4.1.0 - 2018-12-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,6 @@ All Notable changes to `Period` will be documented in this file
 - `Period::before`
 - `Period::around`
 - `Period::fromDatePeriod`
-- `Period::fromCalendar`
-
-added the following constants
-
-- `Period::ISOYEAR`
-- `Period::YEAR`
-- `Period::SEMESTER`
-- `Period::QUARTER`
-- `Period::MONTH`
-- `Period::ISOWEEK`
-- `Period::DAY`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ All Notable changes to `Period` will be documented in this file
 - `Period::fromQuarter`
 - `Period::fromMonth`
 - `Period::fromDay`
-- `Period::fromHour`
-- `Period::fromMinute`
-- `Period::fromSecond`
 - `Period::fromDatepoint`
 - `Period::fromIsoYear`
 - `Period::fromIsoWeek`
@@ -24,6 +21,19 @@ All Notable changes to `Period` will be documented in this file
 - `Period::around`
 - `Period::fromDatePeriod`
 - `Period::fromCalendar`
+
+added the following constants
+
+- `Period::YEAR`
+- `Period::ISOYEAR`
+- `Period::SEMESTER`
+- `Period::QUARTER`
+- `Period::MONTH`
+- `Period::ISOWEEK`
+- `Period::DAY`
+- `Period::HOUR`
+- `Period::MINUTE`
+- `Period::SECOND`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,13 @@ All Notable changes to `Period` will be documented in this file
 
 - `League\Period\Datepoint`
 - `League\Period\Duration`
+- `Period::fromIsoYear`
 - `Period::fromYear`
 - `Period::fromSemester`
 - `Period::fromQuarter`
 - `Period::fromMonth`
-- `Period::fromDay`
-- `Period::fromDatepoint`
-- `Period::fromIsoYear`
 - `Period::fromIsoWeek`
+- `Period::fromDay`
 - `Period::after`
 - `Period::before`
 - `Period::around`
@@ -24,16 +23,13 @@ All Notable changes to `Period` will be documented in this file
 
 added the following constants
 
-- `Period::YEAR`
 - `Period::ISOYEAR`
+- `Period::YEAR`
 - `Period::SEMESTER`
 - `Period::QUARTER`
 - `Period::MONTH`
 - `Period::ISOWEEK`
 - `Period::DAY`
-- `Period::HOUR`
-- `Period::MINUTE`
-- `Period::SECOND`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Security
 
 If you discover any security related issues, please email nyamsprod@gmail.com instead of using the issue tracker.
 
+Changelog
+-------
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+
 Credits
 -------
 

--- a/docs/4.0/comparing.md
+++ b/docs/4.0/comparing.md
@@ -26,10 +26,8 @@ The `$index` argument can be another `Period` object or a datepoint.
 #### Examples
 
 ~~~php
-use function League\Period\month;
-
-$period = month(1983, 4);
-$alt = month(1984, 4);
+$period = Period::fromMonth(1983, 4);
+$alt = Period::fromMonth(1984, 4);
 
 //test against another Period object
 $period->isBefore($alt); //returns true;
@@ -56,10 +54,8 @@ The `$index` argument can be another `Period` object or a datepoint.
 #### Examples
 
 ~~~php
-use League\Period\Period;
-
-$period = month(1983, 4);
-$alt = month(1984, 4);
+$period = Period::fromMonth(1983, 4);
+$alt = Period::fromMonth(1984, 4);
 
 //test against another Period object
 $alt->isAfter($period); //returns true;
@@ -84,10 +80,8 @@ A `Period` abuts if it starts immediately after, or ends immediately before the 
 #### Examples
 
 ~~~php
-use League\Period\Period;
-
-$period = month(2014, 3);
-$alt = month(2014, 4);
+$period = Period::fromMonth(2014, 3);
+$alt = Period::fromMonth(2014, 4);
 $period->abuts($alt); //return true
 //in this case $period->getEndDate() === $alt->getStartDate();
 ~~~
@@ -103,9 +97,9 @@ A `Period` overlaps another if they share some common part of their respective c
 #### Examples
 
 ~~~php
-$orig  = month('2014-03-15');
-$alt   = month('2014-04-15');
-$other = interval_after('2014-03-15', '3 WEEKS');
+$orig  = Period::fromMonth('2014-03-15');
+$alt   = Period::fromMonth('2014-04-15');
+$other = Period::after('2014-03-15', '3 WEEKS');
 
 $orig->overlaps($alt);   //return false
 $orig->overlaps($other); //return true
@@ -123,9 +117,9 @@ Tells whether two `Period` objects shares the same datepoints.
 #### Examples
 
 ~~~php
-$orig  = month(2014, 3);
-$alt   = month(2014, 4);
-$other = interval_after('2014-03-01', '1 MONTH');
+$orig  = Period::fromMonth(2014, 3);
+$alt   = Period::fromMonth(2014, 4);
+$other = Period::after('2014-03-01', '1 MONTH');
 
 $orig->equals($alt);   //return false
 $orig->equals($other); //return true
@@ -148,13 +142,13 @@ The `$index` argument can be another `Period` object or a datepoint.
 
 ~~~php
 //comparing a datetime
-$period = month(1983, 4);
+$period = Period::fromMonth(1983, 4);
 $period->contains('1983-04-15');            //returns true;
 $period->contains($period->getStartDate()); //returns true;
 $period->contains($period->getEndDate());   //returns false;
 
 //comparing two Period objects
-$alt = interval_after('1983-04-12', '12 DAYS');
+$alt = Period::after('1983-04-12', '12 DAYS');
 $period->contains($alt); //return true;
 $alt->contains($period); //return false;
 ~~~
@@ -178,8 +172,8 @@ The difference is expressed as an `array`. The returned array always contains tw
 #### Examples
 
 ~~~php
-$orig = interval_after('2013-01-01', '1 MONTH');
-$alt  = interval_after('2013-01-15', '7 DAYS');
+$orig = Period::after('2013-01-01', '1 MONTH');
+$alt  = Period::after('2013-01-15', '7 DAYS');
 list($first, $last) = $orig->diff($alt);
 // $diff is an array containing 2 Period objects
 $first->equals(new Period('2013-01-01', '2013-01-15')); // returns true
@@ -205,8 +199,8 @@ An Period overlaps another if it shares some common part of the datetime continu
 #### Examples
 
 ~~~php
-$interval = interval_after('2012-01-01', '2 MONTHS');
-$alt_interval = interval_after('2012-01-15', '3 MONTHS');
+$interval = Period::after('2012-01-01', '2 MONTHS');
+$alt_interval = Period::after('2012-01-15', '3 MONTHS');
 $intersection = $interval->intersect($alt_interval);
 ~~~
 
@@ -225,8 +219,8 @@ A `Period` has a gap with another Period if there is a non-zero interval between
 #### Examples
 
 ~~~php
-$interval = interval_after('2012-01-01', '2 MONTHS');
-$alt_interval = interval_after('2013-01-15', '3 MONTHS');
+$interval = Period::after('2012-01-01', '2 MONTHS');
+$alt_interval = Period::after('2013-01-15', '3 MONTHS');
 $gap = $interval->gap($alt_interval);
 ~~~
 
@@ -257,9 +251,9 @@ To ease the method usage you can rely on the following proxy methods:
 #### Examples
 
 ~~~php
-$orig = interval_after('2012-01-01', '1 MONTH');
-$alt = interval_after('2012-01-01', '1 WEEK');
-$other = interval_after('2013-01-01', '1 MONTH');
+$orig = Period::after('2012-01-01', '1 MONTH');
+$alt = Period::after('2012-01-01', '1 WEEK');
+$other = Period::after('2013-01-01', '1 MONTH');
 
 $orig->durationCompare($alt);     //return 1
 $orig->durationGreaterThan($alt); //return true
@@ -289,8 +283,8 @@ Returns the duration difference between two Period objects using a `DateInterval
 ~~~php
 use League\Period\Period;
 
-$interval = semester(2012, 1);
-$alt_interval = iso_week(2012, 4);
+$interval = Period::fromSemester(2012, 1);
+$alt_interval = Period::fromIsoWeek(2012, 4);
 $diff = $interval->dateIntervalDiff($alt_interval);
 // $diff is a DateInterval object
 $diff_as_seconds = $interval->timestampIntervalDiff($alt_interval);

--- a/docs/4.0/datepoint.md
+++ b/docs/4.0/datepoint.md
@@ -1,0 +1,87 @@
+---
+layout: default
+title: The Sequence class
+---
+
+# The Datepoint object
+
+<p class="message-info">The <code>Datepoint</code> class is introduced in <code>version 4.2</code>.</p>
+
+A datepoint is a position in time expressed as a `DateTimeImmutable` object.
+
+The `Datepoint` class is introduced to ease `Datepoint` manipulation. This class extends PHP's `DateTimeImmutable` class by adding a new named constructor and several getter methods.
+
+## Named constructor
+
+### Datepoint::create
+
+~~~php
+public Datepoint::create($datepoint): self
+~~~
+
+Returns a `Datepoint` object or throws:
+
+- a `TypeError` if the submitted parameter have the wrong type.
+- a PHP `Exception` if creating a `Datepoint` fails.
+
+#### parameters
+
+- `$datepoint` can be:
+    - a `DateTimeInterface` implementing object
+    - a string parsable by the `DateTime` constructor.
+    - an integer interpreted as a timestamp.
+
+<p class="message-info">Because we are using PHP's parser, values exceeding ranges will be added to their parent values.</p>
+
+<p class="message-info">If no timezone information is given, the returned <code>Datepoint</code> object will use the current timezone.</p>
+
+#### examples
+
+Using the `$datepoint` argument
+
+~~~php
+use League\Period\Datepoint;
+
+Datepoint::create('yesterday'); // returns new Datepoint('yesterday')
+Datepoint::create('2018');      // returns new Datepoint('@2018')
+Datepoint::create(2018);        // returns new Datepoint('@2018')
+Datepoint::create(new DateTime('2018-10-15'));  // returns new Datepoint('2018-10-15')
+Datepoint::create(new DateTimeImmutable('2018-10-15'));  // returns new Datepoint('2018-10-15')
+~~~
+
+## Accessing calendar interval
+
+Once you've got a `Datepoint` instantiated object, you can access a set of calendar type interval using the following methods.
+
+~~~php
+public Datepoint::getSecond(): Period;
+public Datepoint::getMinute(): Period
+public Datepoint::getHour(): Period
+public Datepoint::getDay(): Period
+public Datepoint::getIsoWeek(): Period
+public Datepoint::getMonth(): Period
+public Datepoint::getQuarter(): Period
+public Datepoint::getSemester(): Period
+public Datepoint::getYear(): Period
+public Datepoint::getIsoYear(): Period
+~~~
+
+For each a these methods a `Period` object is returned with:
+
+- the starting datepoint represents the beginning of the current datepoint calendar interval;
+- the duration associated with the given calendar interval;
+
+#### Examples
+
+~~~php
+use League\Period\Datepoint;
+
+$datepoint = new Datepoint('2018-06-18 08:35:25');
+$hour = $datepoint->getHour();
+// new Period('2018-06-18 08:00:00', '2018-06-18 09:00:00');
+$month = $datepoint->getMonth();
+// new Period('2018-06-01 00:00:00', '2018-07-01 00:00:00');
+$month->contains($datepoint); // true
+$hour->contains($datepoint); // true
+$month->contains($hour); // true
+~~~

--- a/docs/4.0/definitions.md
+++ b/docs/4.0/definitions.md
@@ -21,14 +21,11 @@ title: Concepts and arguments
 
 Since this package relies heavily on `DateTimeImmutable` and `DateInterval` objects and because it is sometimes complicated to get your hands on such objects the package comes bundled with two simple functions that are used throughout the library to ensure typesafety. These functions are defined under the `League\Period` namespace.
 
-<p class="message-notice">the <code>Datepoint</code> and <code>Duration</code> classes are added since <code>version 4.2</code></p>
-
-<p class="message-notice">the <code>datepoint</code> and <code>duration</code> functions are deprecated since <code>version 4.2</code></p>
+<p class="message-notice">the <code>datepoint</code> and <code>duration</code> functions are deprecated since <code>version 4.2</code> Your encouraged to use the <a href="/4.0/datepoint/">Datepoint</a> and <a href="/4.0/duration/">Duration</a> classes instead.</p>
 
 ### datepoint
 
 ~~~php
-League\Period\Datepoint::create(mixed $datepoint): DateTimeImmutable;
 function League\Period\datepoint(mixed $datepoint): DateTimeImmutable;
 ~~~
 
@@ -53,7 +50,6 @@ Returns a `DateTimeImmutable` object or throws:
 Using the `$datepoint` argument
 
 ~~~php
-use League\Period\Datepoint;
 use function League\Period\datepoint;
 
 datepoint('yesterday'); // returns new DateTimeImmutable('yesterday')
@@ -61,18 +57,11 @@ datepoint('2018');      // returns new DateTimeImmutable('@2018')
 datepoint(2018);        // returns new DateTimeImmutable('@2018')
 datepoint(new DateTime('2018-10-15'));  // returns new DateTimeImmutable('2018-10-15')
 datepoint(new DateTimeImmutable('2018-10-15'));  // returns new DateTimeImmutable('2018-10-15')
-
-Datepoint::create('yesterday'); // returns new DateTimeImmutable('yesterday')
-Datepoint::create('2018');      // returns new DateTimeImmutable('@2018')
-Datepoint::create(2018);        // returns new DateTimeImmutable('@2018')
-Datepoint::create(new DateTime('2018-10-15'));  // returns new DateTimeImmutable('2018-10-15')
-Datepoint::create(new DateTimeImmutable('2018-10-15'));  // returns new DateTimeImmutable('2018-10-15')
 ~~~
 
 ### duration
 
 ~~~php
-League\Period\Duration::create(mixed $duration): DateInterval;
 function League\Period\duration(mixed $duration): DateInterval;
 ~~~
 
@@ -92,7 +81,6 @@ Converts its single input into a `DateInterval` object or throws a `TypeError` o
 ### Examples
 
 ~~~php
-use League\Period\Duration;
 use League\Period\Period;
 use function League\Period\duration;
 
@@ -100,10 +88,5 @@ duration('1 DAY');                  // returns new DateInterval('P1D')
 duration(2018);                     // returns new DateInterval('PT2018S')
 duration(new DateInterval('PT1H')); // returns new DateInterval('PT1H')
 duration(new Period('now', 'tomorrow'));
-// returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
-
-Duration::create('1 DAY');                  // returns new DateInterval('P1D')
-Duration::create(2018);                     // returns new DateInterval('PT2018S')
-Duration::create(new Period('now', 'tomorrow'));
 // returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
 ~~~

--- a/docs/4.0/definitions.md
+++ b/docs/4.0/definitions.md
@@ -21,9 +21,14 @@ title: Concepts and arguments
 
 Since this package relies heavily on `DateTimeImmutable` and `DateInterval` objects and because it is sometimes complicated to get your hands on such objects the package comes bundled with two simple functions that are used throughout the library to ensure typesafety. These functions are defined under the `League\Period` namespace.
 
+<p class="message-notice">the <code>Datepoint</code> and <code>Duration</code> classes are added since <code>version 4.2</code></p>
+
+<p class="message-notice">the <code>datepoint</code> and <code>duration</code> functions are deprecated since <code>version 4.2</code></p>
+
 ### datepoint
 
 ~~~php
+League\Period\Datepoint::create(mixed $datepoint): DateTimeImmutable;
 function League\Period\datepoint(mixed $datepoint): DateTimeImmutable;
 ~~~
 
@@ -48,6 +53,7 @@ Returns a `DateTimeImmutable` object or throws:
 Using the `$datepoint` argument
 
 ~~~php
+use League\Period\Datepoint;
 use function League\Period\datepoint;
 
 datepoint('yesterday'); // returns new DateTimeImmutable('yesterday')
@@ -55,11 +61,18 @@ datepoint('2018');      // returns new DateTimeImmutable('@2018')
 datepoint(2018);        // returns new DateTimeImmutable('@2018')
 datepoint(new DateTime('2018-10-15'));  // returns new DateTimeImmutable('2018-10-15')
 datepoint(new DateTimeImmutable('2018-10-15'));  // returns new DateTimeImmutable('2018-10-15')
+
+Datepoint::create('yesterday'); // returns new DateTimeImmutable('yesterday')
+Datepoint::create('2018');      // returns new DateTimeImmutable('@2018')
+Datepoint::create(2018);        // returns new DateTimeImmutable('@2018')
+Datepoint::create(new DateTime('2018-10-15'));  // returns new DateTimeImmutable('2018-10-15')
+Datepoint::create(new DateTimeImmutable('2018-10-15'));  // returns new DateTimeImmutable('2018-10-15')
 ~~~
 
 ### duration
 
 ~~~php
+League\Period\Duration::create(mixed $duration): DateInterval;
 function League\Period\duration(mixed $duration): DateInterval;
 ~~~
 
@@ -79,20 +92,18 @@ Converts its single input into a `DateInterval` object or throws a `TypeError` o
 ### Examples
 
 ~~~php
-use function League\Period\datepoint;
+use League\Period\Duration;
+use League\Period\Period;
 use function League\Period\duration;
 
-$daterange = new DatePeriod(
-    datepoint(123456789),
-    duration(600),
-    datepoint(new DateTime())
-);
+duration('1 DAY');                  // returns new DateInterval('P1D')
+duration(2018);                     // returns new DateInterval('PT2018S')
+duration(new DateInterval('PT1H')); // returns new DateInterval('PT1H')
+duration(new Period('now', 'tomorrow'));
+// returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
 
-//returns the same object as if you had written
-
-$daterange = new DatePeriod(
-    new DateTimeImmutable('@123456789'),
-    new DateInterval('PT600S'),
-    new DateTimeImmutable()
-);
+Duration::create('1 DAY');                  // returns new DateInterval('P1D')
+Duration::create(2018);                     // returns new DateInterval('PT2018S')
+Duration::create(new Period('now', 'tomorrow'));
+// returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
 ~~~

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: The Sequence class
+---
+
+# The Duration object
+
+<p class="message-info">The <code>Duration</code> class is introduced in <code>version 4.2</code>.</p>
+
+A duration is the continuous portion of time between two datepoints expressed as a `DateInterval` object. The duration cannot be negative.
+
+The `Duration` class is introduced to ease duration manipulation. This class extends PHP's `DateInterval` class by adding a new named constructor.
+
+## Named constructor
+
+### Duration::create
+
+~~~php
+public Duration::create($duration): self
+~~~
+
+Converts its single input into a `Duration` object or throws a `TypeError` otherwise.
+
+#### parameter
+
+`$duration` can be:
+
+- a `League\Period\Period` object;
+- a `DateInterval` object;
+- a string parsable by the `DateInterval::createFromDateString` method.
+- an integer interpreted as the interval expressed in seconds.
+
+<p class="message-warning"><strong>WARNING:</strong> When the string is not parsable by <code>DateInterval::createFromDateString</code> a <code>DateInterval</code> object representing the <code>0</code> interval is returned as described in <a href="https://bugs.php.net/bug.php?id=50020">PHP bug #50020</a>.</p>
+
+### Examples
+
+~~~php
+use League\Period\Duration;
+use League\Period\Period;
+
+Duration::create('1 DAY');                  // returns new DateInterval('P1D')
+Duration::create(2018);                     // returns new DateInterval('PT2018S')
+Duration::create(new DateInterval('PT1H')); // returns new DateInterval('PT1H')
+Duration::create(new Period('now', 'tomorrow'));
+// returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
+~~~

--- a/docs/4.0/index.md
+++ b/docs/4.0/index.md
@@ -41,9 +41,7 @@ Learn more about how this all works in the [basic usage](/4.0/properties/).
 A simple example on how to get all the days from a selected month.
 
 ~~~php
-use function League\Period\month;
-
-foreach (month(2014, 10)->getDatePeriod('1 DAY') as $day) {
+foreach (Period::fromMonth(2014, 10)->getDatePeriod('1 DAY') as $day) {
     $day->format('Y-m-d');
 }
 ~~~
@@ -53,11 +51,8 @@ To help easily instantiate your time range and manipulating it, the package come
 ## Comparing intervals
 
 ~~~php
-use function League\Period\interval_after;
-use function League\Period\iso_week;
-
-$interval = interval_after('2014-01-01', '1 WEEK');
-$alt_interval = iso_week(2014, 1);
+$interval = Period::after('2014-01-01', '1 WEEK');
+$alt_interval = Period::fromIsoWeek(2014, 1);
 $interval->durationEquals($alt_interval); //returns true
 $interval->equals($alt_interval);         //returns false
 ~~~
@@ -67,9 +62,7 @@ The class comes with other ways to [compare time ranges](/4.0/comparing/) based 
 ## Modifying interval
 
 ~~~php
-use function League\Period\interval_after;
-
-$period = interval_after('2014-01-01', '1 WEEK');
+$period = Period::after('2014-01-01', '1 WEEK');
 $altPeriod = $period->endingOn('2014-02-03');
 $period->contains($altPeriod); //return false;
 $altPeriod->durationGreaterThan($period); //return true;

--- a/docs/4.0/instantiation.md
+++ b/docs/4.0/instantiation.md
@@ -105,13 +105,11 @@ $day->getStartDate()->format('Y-m-d H:i:s'); //return 2012-01-01 00:00:00
 public static Period::after(mixed $datepoint, mixed $duration): Period
 public static Period::before(mixed $datepoint, mixed $duration): Period
 public static Period::around(mixed $datepoint, mixed $duration): Period
-public static Period::fromCalendar(mixed $datepoint, string $calendar): Period
 ~~~
 
 - `Period::after` returns a `Period` object which starts at `$datepoint`
 - `Period::before` returns a `Period` object which ends at `$datepoint`
 - `Period::around` returns a `Period` object where the given duration is simultaneously substracted from and added to the `$datepoint`.
-- `Period::fromCalendar`returns the closest `Period` containing the submitted datepoint depending on the referenced calendar.
 
 #### Parameters
 
@@ -119,14 +117,6 @@ public static Period::fromCalendar(mixed $datepoint, string $calendar): Period
 
 - `$datepoint`: represents a datepoint
 - `$duration` represents a duration.
-- `$calendar`: a calendar reference to determine the period datepoint. In can be set to the following constants:
-	- `Period::YEAR`
-	- `Period::ISOYEAR`
-	- `Period::SEMESTER`
-	- `Period::QUARTER`
-	- `Period::MONTH`
-	- `Period::ISOWEEK`
-	- `Period::DAY`
 
 #### Examples
 

--- a/docs/4.0/instantiation.md
+++ b/docs/4.0/instantiation.md
@@ -127,9 +127,6 @@ public static Period::fromCalendar(mixed $datepoint, string $calendar): Period
 	- `Period::MONTH`
 	- `Period::ISOWEEK`
 	- `Period::DAY`
-	- `Period::HOUR`
-	- `Period::MINUTE`
-	- `Period::SECOND`
 
 #### Examples
 

--- a/docs/4.0/instantiation.md
+++ b/docs/4.0/instantiation.md
@@ -74,9 +74,6 @@ $interval = Period::fromDatePeriod($daterange);
 <p class="message-notice">The week index follows the <a href="https://en.wikipedia.org/wiki/ISO_week_date" target="_blank">ISO week date</a> system. This means that the first week may be included in the previous year, conversely the last week may be included in the next year.</p>
 
 ~~~php
-public static Period::fromSecond(int $year, int $month = 1, int $day = 1, int $hour = 0, int $minute = 0, int $second = 0): Period
-public static Period::fromMinute(int $year, int $month = 1, int $day = 1, int $hour = 0, int $minute = 0): Period
-public static Period::fromHour(int $year, int $month = 1, int $day = 1, int $hour = 0): Period
 public static Period::fromDay(int $year, int $month = 1, int $day = 1): Period
 public static Period::fromIsoWeek(int $year, int $week = 1): Period
 public static Period::fromMonth(int $year, int $month = 1): Period
@@ -89,18 +86,13 @@ public static Period::fromIsoYear(int $year): Period
 #### Parameters
 
 - `$year` parameter is always required;
-- the `$year`, `$semester`, `$quarter`, `$month`, `$day` arguments will default to `1`;
-- the `$hour`, `$minute`, `$second` arguments will default to `0`;
+- the `$semester`, `$quarter`, `$month`, `$week`, `$day` arguments will default to `1`;
 
 <p class="message-info">The datepoints will be created following PHP <code>DateTimeImmutable::setDate</code>, <code>DateTimeImmutable::setISODate</code> and <code>DateTimeImmutable::setTime</code> rules<br> which means that overflow is possible and acceptable.</p>
 
 #### Examples
 
 ~~~php
-$hour  = Period::fromHour(2012, 4, 1, 8);
-$alt_hour = new Period('2012-04-01 08:00:00', '2012-04-01 09:00:00');
-$alt_hour->equals($hour); //return true;
-
 $day = Period::fromDay(2012);
 $daybis = Period::fromDay(2012, 1);
 $day->equals($daybis); //return true;
@@ -110,14 +102,12 @@ $day->getStartDate()->format('Y-m-d H:i:s'); //return 2012-01-01 00:00:00
 ### Named constructors accepting a datepoint and/or a duration
 
 ~~~php
-public static Period::fromDatepoint(mixed $datepoint): Period
 public static Period::after(mixed $datepoint, mixed $duration): Period
 public static Period::before(mixed $datepoint, mixed $duration): Period
 public static Period::around(mixed $datepoint, mixed $duration): Period
 public static Period::fromCalendar(mixed $datepoint, string $calendar): Period
 ~~~
 
-- `Period::fromDatepoint` returns a `Period` instance which represents an instant
 - `Period::after` returns a `Period` object which starts at `$datepoint`
 - `Period::before` returns a `Period` object which ends at `$datepoint`
 - `Period::around` returns a `Period` object where the given duration is simultaneously substracted from and added to the `$datepoint`.
@@ -130,28 +120,18 @@ public static Period::fromCalendar(mixed $datepoint, string $calendar): Period
 - `$datepoint`: represents a datepoint
 - `$duration` represents a duration.
 - `$calendar`: a calendar reference to determine the period datepoint. In can be set to the following constants:
-	- `Period::CALENDAR_YEAR`
-	- `Period::CALENDAR_ISOYEAR`
-	- `Period::CALENDAR_SEMESTER`
-	- `Period::CALENDAR_QUARTER`
-	- `Period::CALENDAR_MONTH`
-	- `Period::CALENDAR_ISOWEEK`
-	- `Period::CALENDAR_DAY`
-	- `Period::CALENDAR_HOUR`
-	- `Period::CALENDAR_MINUTE`
-	- `Period::CALENDAR_SECOND`
+	- `Period::YEAR`
+	- `Period::ISOYEAR`
+	- `Period::SEMESTER`
+	- `Period::QUARTER`
+	- `Period::MONTH`
+	- `Period::ISOWEEK`
+	- `Period::DAY`
+	- `Period::HOUR`
+	- `Period::MINUTE`
+	- `Period::SECOND`
 
 #### Examples
-
-Using `Period::fromDatepoint`:
-
-~~~php
-use League\Period;
-
-$period = Period::fromDatepoint('2018-12-15 08:37:12');
-
-$period->getStartDate() == $period->getEndate(); // true
-~~~
 
 Using `Period::after`, `Period::around`, `Period::before`:
 
@@ -172,7 +152,7 @@ Using `Period::fromCalendar`:
 ~~~php
 use League\Period;
 
-$period = Period::fromCalendar('2018-12-15 08:37:12', Period::CALENDAR_HOUR);
+$period = Period::fromCalendar('2018-12-15 08:37:12', Period::HOUR);
 $alt_period = new Period('2018-12-15 08:00:00', '2018-12-15 09:00:00');
 
 $alt_period->equals($period);

--- a/docs/4.0/instantiation.md
+++ b/docs/4.0/instantiation.md
@@ -32,8 +32,155 @@ $period = new Period('2012-04-01 08:30:25', new DateTime('2013-09-04 12:35:21'))
 
 <p class="message-info"><code>datepoint</code> conversion is done internally using the <a href="/4.0/definitions/#datepoint">League\Period\datepoint</a> function</p>
 
+## Named constructors
+
+<p class="message-notice">Since <code>version 4.2</code></p>
+
+Apart from its constructor, to ease the class instantiation you can rely on many built in named constructors to return a new `Period` object.
+
+### Named constructors accepting a DatePeriod object
+
+~~~php
+function Period::fromDatePeriod(DatePeriod $datePeriod): Period
+~~~
+
+#### Parameter
+
+- `$datePeriod` is a `DatePeriod` object.
+
+#### Example
+
+~~~php
+$daterange = new DatePeriod(
+	new DateTime('2012-08-01'),
+	new DateInterval('PT1H'),
+	new DateTime('2012-08-31')
+);
+$interval = Period::fromDatePeriod($daterange);
+$interval->getStartDate() == $daterange->getStartDate();
+$interval->getEndDate() == $daterange->getEndDate();
+~~~
+
+<p class="message-warning">If the submitted <code>DatePeriod</code> instance does not have a ending datepoint, It will trigger a <code>TypeError</code> error. This is possible if the <code>DatePeriod</code> instance was created using recurrences only</p>
+
+~~~php
+$daterange = new DatePeriod('R4/2012-07-01T00:00:00Z/P7D');
+$interval = Period::fromDatePeriod($daterange);
+//throws a TypeError error because $daterange->getEndDate() returns null
+~~~
+
+### Named constructors accepting a list of integer arguments
+
+<p class="message-notice">The week index follows the <a href="https://en.wikipedia.org/wiki/ISO_week_date" target="_blank">ISO week date</a> system. This means that the first week may be included in the previous year, conversely the last week may be included in the next year.</p>
+
+~~~php
+public static Period::fromSecond(int $year, int $month = 1, int $day = 1, int $hour = 0, int $minute = 0, int $second = 0): Period
+public static Period::fromMinute(int $year, int $month = 1, int $day = 1, int $hour = 0, int $minute = 0): Period
+public static Period::fromHour(int $year, int $month = 1, int $day = 1, int $hour = 0): Period
+public static Period::fromDay(int $year, int $month = 1, int $day = 1): Period
+public static Period::fromIsoWeek(int $year, int $week = 1): Period
+public static Period::fromMonth(int $year, int $month = 1): Period
+public static Period::fromQuarter(int $year, int $quarter = 1): Period
+public static Period::fromSemester(int $year, int $semester = 1): Period
+public static Period::fromYear(int $year): Period
+public static Period::fromIsoYear(int $year): Period
+~~~
+
+#### Parameters
+
+- `$year` parameter is always required;
+- the `$year`, `$semester`, `$quarter`, `$month`, `$day` arguments will default to `1`;
+- the `$hour`, `$minute`, `$second` arguments will default to `0`;
+
+<p class="message-info">The datepoints will be created following PHP <code>DateTimeImmutable::setDate</code>, <code>DateTimeImmutable::setISODate</code> and <code>DateTimeImmutable::setTime</code> rules<br> which means that overflow is possible and acceptable.</p>
+
+#### Examples
+
+~~~php
+$hour  = Period::fromHour(2012, 4, 1, 8);
+$alt_hour = new Period('2012-04-01 08:00:00', '2012-04-01 09:00:00');
+$alt_hour->equals($hour); //return true;
+
+$day = Period::fromDay(2012);
+$daybis = Period::fromDay(2012, 1);
+$day->equals($daybis); //return true;
+$day->getStartDate()->format('Y-m-d H:i:s'); //return 2012-01-01 00:00:00
+~~~
+
+### Named constructors accepting a datepoint and/or a duration
+
+~~~php
+public static Period::fromDatepoint(mixed $datepoint): Period
+public static Period::after(mixed $datepoint, mixed $duration): Period
+public static Period::before(mixed $datepoint, mixed $duration): Period
+public static Period::around(mixed $datepoint, mixed $duration): Period
+public static Period::fromCalendar(mixed $datepoint, string $calendar): Period
+~~~
+
+- `Period::fromDatepoint` returns a `Period` instance which represents an instant
+- `Period::after` returns a `Period` object which starts at `$datepoint`
+- `Period::before` returns a `Period` object which ends at `$datepoint`
+- `Period::around` returns a `Period` object where the given duration is simultaneously substracted from and added to the `$datepoint`.
+- `Period::fromCalendar`returns the closest `Period` containing the submitted datepoint depending on the referenced calendar.
+
+#### Parameters
+
+<p class="message-info"><code>datepoint</code> and <code>duration</code> conversions are done internally using the <a href="/4.0/definitions/#datepoint">League\Period\datepoint</a> and the <a href="/4.0/definitions/#duration">League\Period\duration</a> functions.</p>
+
+- `$datepoint`: represents a datepoint
+- `$duration` represents a duration.
+- `$calendar`: a calendar reference to determine the period datepoint. In can be set to the following constants:
+	- `Period::CALENDAR_YEAR`
+	- `Period::CALENDAR_ISOYEAR`
+	- `Period::CALENDAR_SEMESTER`
+	- `Period::CALENDAR_QUARTER`
+	- `Period::CALENDAR_MONTH`
+	- `Period::CALENDAR_ISOWEEK`
+	- `Period::CALENDAR_DAY`
+	- `Period::CALENDAR_HOUR`
+	- `Period::CALENDAR_MINUTE`
+	- `Period::CALENDAR_SECOND`
+
+#### Examples
+
+Using `Period::fromDatepoint`:
+
+~~~php
+use League\Period;
+
+$period = Period::fromDatepoint('2018-12-15 08:37:12');
+
+$period->getStartDate() == $period->getEndate(); // true
+~~~
+
+Using `Period::after`, `Period::around`, `Period::before`:
+
+~~~php
+$date = datepoint('2012-04-01 08:30:25');
+$duration = duration('1 DAY');
+$half_duration = duration('12 HOURS');
+
+$interval_after = Period::after($date, $duration);
+$interval_before = Period::before($date->add($duration), $duration);
+$interval_after->equals($interval_before); //returns true
+$interval_around = Period::around($date->add($half_duration), $half_duration);
+$interval_around->equals($interval_before); //returns true
+~~~
+
+Using `Period::fromCalendar`:
+
+~~~php
+use League\Period;
+
+$period = Period::fromCalendar('2018-12-15 08:37:12', Period::CALENDAR_HOUR);
+$alt_period = new Period('2018-12-15 08:00:00', '2018-12-15 09:00:00');
+
+$alt_period->equals($period);
+~~~
 
 ## Helper functions
+
+<p class="message-notice">The following functions are deprecated since <code>version 4.2</code> and will be remove in the next major release. Please consider using the named constructors instead.</p>
 
 Apart from its constructor, to ease the class instantiation you can rely on many built in helper functions to return a new `Period` object. All helper functions are declared under the `League\Period` namespace.
 

--- a/docs/4.0/modifying.md
+++ b/docs/4.0/modifying.md
@@ -26,7 +26,7 @@ Returns a new `Period` object with `$datepoint` as the new **starting included d
 #### Example
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->startingOn('2014-02-01');
 $interval->getStartDate(); //returns DateTimeImmutable('2014-03-01');
 $new_interval->getStartDate(); //returns DateTimeImmutable('2014-02-01');
@@ -44,7 +44,7 @@ Returns a new `Period` object with `$datepoint` as the new **ending excluded dat
 #### Example
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->EndingOn('2014-03-16');
 $interval->getEndDate(); //returns DateTimeImmutable('2014-04-01');
 $new_interval->getEndDate(); //returns DateTimeImmutable('2014-03-16');
@@ -64,7 +64,7 @@ Returns a new `Period` object by updating its duration. Only the excluded ending
 #### Example
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->withDurationAfterStart('2 WEEKS');
 $interval->getEndDate();    //returns DateTimeImmutable('2014-04-01');
 $new_interval->getEndDate(); //returns DateTimeImmutable('2014-03-16');
@@ -82,7 +82,7 @@ Returns a new `Period` object by updating its duration. Only the included starti
 #### Example
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->withDurationBeforeEnd('2 DAYS');
 $interval->getStartDate();    //returns DateTimeImmutable('2014-03-01');
 $new_interval->getStartDate(); //returns DateTimeImmutable('2014-03-30');
@@ -100,7 +100,7 @@ Returns a new `Period` object where the endpoints are moved forward or backward 
 #### Example
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->move('1 MONTH');
 $interval->getStartDate()     //returns DateTimeImmutable('2014-03-01');
 $interval->getEndDate();      //returns DateTimeImmutable('2014-04-01');
@@ -119,7 +119,7 @@ Returns a new `Period` object where the starting endpoint is moved forward or ba
 #### Example
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->moveStartDate('-1 MONTH');
 $interval->getStartDate()     //returns DateTimeImmutable('2014-03-01');
 $interval->getEndDate();      //returns DateTimeImmutable('2014-04-01');
@@ -138,7 +138,7 @@ Returns a new `Period` object where the ending endpoint is moved forward or back
 #### Example
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->moveEndtDate('1 MONTH');
 $interval->getStartDate()     //returns DateTimeImmutable('2014-03-01');
 $interval->getEndDate();      //returns DateTimeImmutable('2014-04-01');
@@ -160,7 +160,7 @@ Returns a new `Period` object where the given interval is:
 #### Example
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->expand('1 MONTH');
 $interval->getStartDate()     //returns DateTimeImmutable('2014-03-01');
 $interval->getEndDate();      //returns DateTimeImmutable('2014-04-01');
@@ -171,7 +171,7 @@ $new_interval->getEndDate();   //returns DateTimeImmutable('2014-05-01');
 <p class="message-info">If you need to shrink the time range you can simply use a <strong>inverted</strong> <code>DateInterval</code> object</p>
 
 ~~~php
-$interval = month(2014, 3);
+$interval = Period::fromMonth(2014, 3);
 $new_interval = $interval->expand('-1 DAY');
 $interval->getStartDate();     //returns DateTimeImmutable('2014-03-01');
 $interval->getEndDate();      //returns DateTimeImmutable('2014-04-01');
@@ -192,9 +192,9 @@ Merges two or more `Period` objects by returning a new `Period` object which eng
 #### Example
 
 ~~~php
-$interval = semester(2012, 1);
-$alt = iso_week(2013, 4);
-$other = interval_after('2012-03-07 08:10:27', 86000*3);
+$interval = Period::fromSemester(2012, 1);
+$alt = Period::fromIsoWeek(2013, 4);
+$other = Period::after('2012-03-07 08:10:27', 86000*3);
 $merge_interval = $interval->merge($alt, $other);
 // $merge_interval->getStartDate() equals $period->getStartDate();
 // $merge_interval->getEndDate() equals $altPeriod->getEndDate();

--- a/docs/4.0/properties.md
+++ b/docs/4.0/properties.md
@@ -47,9 +47,7 @@ Returns a `DatePeriod` using the `Period` datepoints with the given `$duration`.
 #### Examples
 
 ~~~php
-use function League\Period\year;
-
-foreach (year(2012)->getDatePeriod('1 MONTH') as $datetime) {
+foreach (Period::fromYear(2012)->getDatePeriod('1 MONTH') as $datetime) {
     echo $datetime->format('Y-m-d');
 }
 //will iterate 12 times
@@ -60,7 +58,7 @@ foreach (year(2012)->getDatePeriod('1 MONTH') as $datetime) {
 Using the `$option` parameter
 
 ~~~php
-$interval = year('2012-06-05');
+$interval = Period::fromYear('2012-06-05');
 $datePeriod = $interval->getDatePeriod('1 MONTH', DatePeriod::EXCLUDE_START_DATE);
 foreach ($datePeriod as $datetime) {
     echo $datetime->format('Y-m-d');
@@ -88,9 +86,7 @@ Returns a `Generator` to allow iteration over the instance datepoints, recurring
 #### Examples
 
 ~~~php
-use function League\Period\year;
-
-foreach (year(2012)->getDatePeriodBackwards('1 MONTH') as $datetime) {
+foreach (Period::fromYear(2012)->getDatePeriodBackwards('1 MONTH') as $datetime) {
     echo $datetime->format('Y-m-d');
 }
 //will iterate 12 times
@@ -101,7 +97,7 @@ foreach (year(2012)->getDatePeriodBackwards('1 MONTH') as $datetime) {
 Using the `$option` parameter
 
 ~~~php
-$interval = year('2012-06-05');
+$interval = Period::fromYear('2012-06-05');
 $datePeriod = $interval->getDatePeriodBackwards('1 MONTH', DatePeriod::EXCLUDE_START_DATE);
 foreach ($datePeriod as $datetime) {
     echo $datetime->format('Y-m-d');
@@ -132,7 +128,7 @@ This method splits a given `Period` object in smaller `Period` objects according
 #### Example
 
 ~~~php
-foreach (year(2012)->split('1 MONTH') as $inner_periods) {
+foreach (Period::fromYear(2012)->split('1 MONTH') as $inner_periods) {
     echo $inner_period; //returns Period object whose interval is 1 MONTH
 }
 //will iterate 12 times
@@ -158,7 +154,7 @@ This method splits a given `Period` object in smaller `Period` objects according
 ~~~php
 date_default_timezone_set('Africa/Kinshasa');
 
-$collection = iterator_to_array(year(2012)->splitBackwards('5 MONTH'));
+$collection = iterator_to_array(Period::fromYear(2012)->splitBackwards('5 MONTH'));
 echo $collection[0]; // 2012-07-31T23:00:00Z/2012-12-31T23:00:00Z (5 months interval)
 echo $collection[1]; // 2012-02-29T23:00:00Z/2012-07-31T23:00:00Z (5 months interval)
 echo $collection[2]; // 2011-12-31T23:00:00Z/2012-02-29T23:00:00Z (2 months interval)

--- a/docs/4.0/sequence/container.md
+++ b/docs/4.0/sequence/container.md
@@ -70,7 +70,7 @@ Returns the offset of the given `Period` object. The comparison of two intervals
 ~~~php
 $sequence = new Sequence(new Period('2018-01-01', '2018-01-31'));
 $sequence->indexOf(new Period('2018-03-01', '2018-03-31')); // 0
-$sequence->indexOf(day('2012-06-03')); // false
+$sequence->indexOf(Period::fromCalendar('2012-06-03', Period::CALENDAR_DAY)); // false
 ~~~
 
 ### Sequence::contains

--- a/docs/4.0/sequence/container.md
+++ b/docs/4.0/sequence/container.md
@@ -70,7 +70,7 @@ Returns the offset of the given `Period` object. The comparison of two intervals
 ~~~php
 $sequence = new Sequence(new Period('2018-01-01', '2018-01-31'));
 $sequence->indexOf(new Period('2018-03-01', '2018-03-31')); // 0
-$sequence->indexOf(Period::fromCalendar('2012-06-03', Period::CALENDAR_DAY)); // false
+$sequence->indexOf(Period::fromCalendar('2012-06-03', Period::DAY)); // false
 ~~~
 
 ### Sequence::contains

--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -6,6 +6,8 @@ version:
             Upgrading from 3.x: '/4.0/upgrading/'
         Definitions:
             Arguments: '/4.0/definitions/'
+            Datepoint: '/4.0/datepoint/'
+            Duration: '/4.0/duration/'
         Period:
             Instantiation: '/4.0/instantiation/'
             Properties: '/4.0/properties/'

--- a/src/Datepoint.php
+++ b/src/Datepoint.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com).
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\Period;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use TypeError;
+use function filter_var;
+use function get_class;
+use function gettype;
+use function is_object;
+use function is_string;
+use function sprintf;
+use const FILTER_VALIDATE_INT;
+
+/**
+ * League Period Datepoint.
+ *
+ * @package League.period
+ * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ * @since   4.2.0
+ */
+final class Datepoint
+{
+    /**
+     * @codeCoverageIgnore
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Returns a position in time expressed as a DateTimeImmutable object.
+     *
+     * A datepoint can be
+     * <ul>
+     * <li>a DateTimeInterface object
+     * <li>a integer interpreted as a timestamp
+     * <li>a string parsable by DateTime::__construct
+     * </ul>
+     *
+     * @param mixed $datepoint a position in time
+     */
+    public static function create($datepoint): DateTimeImmutable
+    {
+        if ($datepoint instanceof DateTimeImmutable) {
+            return $datepoint;
+        }
+
+        if ($datepoint instanceof DateTime) {
+            return DateTimeImmutable::createFromMutable($datepoint);
+        }
+
+        if (false !== ($timestamp = filter_var($datepoint, FILTER_VALIDATE_INT))) {
+            return new DateTimeImmutable('@'.$timestamp);
+        }
+
+        if (is_string($datepoint)) {
+            return new DateTimeImmutable($datepoint);
+        }
+
+        throw new TypeError(sprintf(
+            'The datepoint must be expressed using an integer, a string or a DateTimeInterface object %s given',
+            is_object($datepoint) ? get_class($datepoint) : gettype($datepoint)
+        ));
+    }
+}

--- a/src/Datepoint.php
+++ b/src/Datepoint.php
@@ -16,13 +16,7 @@ namespace League\Period;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use TypeError;
 use function filter_var;
-use function get_class;
-use function gettype;
-use function is_object;
-use function is_string;
-use function sprintf;
 use const FILTER_VALIDATE_INT;
 
 /**
@@ -32,15 +26,8 @@ use const FILTER_VALIDATE_INT;
  * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @since   4.2.0
  */
-final class Datepoint
+final class Datepoint extends DateTimeImmutable
 {
-    /**
-     * @codeCoverageIgnore
-     */
-    private function __construct()
-    {
-    }
-
     /**
      * Returns a position in time expressed as a DateTimeImmutable object.
      *
@@ -60,20 +47,13 @@ final class Datepoint
         }
 
         if ($datepoint instanceof DateTime) {
-            return DateTimeImmutable::createFromMutable($datepoint);
+            return self::createFromMutable($datepoint);
         }
 
         if (false !== ($timestamp = filter_var($datepoint, FILTER_VALIDATE_INT))) {
-            return new DateTimeImmutable('@'.$timestamp);
+            return new self('@'.$timestamp);
         }
 
-        if (is_string($datepoint)) {
-            return new DateTimeImmutable($datepoint);
-        }
-
-        throw new TypeError(sprintf(
-            'The datepoint must be expressed using an integer, a string or a DateTimeInterface object %s given',
-            is_object($datepoint) ? get_class($datepoint) : gettype($datepoint)
-        ));
+        return new self($datepoint);
     }
 }

--- a/src/Datepoint.php
+++ b/src/Datepoint.php
@@ -17,6 +17,7 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use function filter_var;
 use function intdiv;
 use const FILTER_VALIDATE_INT;
@@ -59,14 +60,97 @@ final class Datepoint extends DateTimeImmutable
         return new self($datepoint);
     }
 
-    public function extractDay(): Period
+    /**
+     * @inheritdoc
+     *
+     * @param string $format
+     * @param string $datetime
+     *
+     * @return self|bool
+     */
+    public static function createFromFormat($format, $datetime, DateTimeZone $timezone = null)
+    {
+        $datepoint = parent::createFromFormat($format, $datetime, $timezone);
+        if (false !== $datepoint) {
+            return self::create($datepoint);
+        }
+
+        return $datepoint;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @param DateTime $datetime
+     */
+    public static function createFromMutable($datetime): self
+    {
+        return self::create(parent::createFromMutable($datetime));
+    }
+
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint second
+     *  - the duration is equal to 1 second
+     */
+    public function getSecond(): Period
+    {
+        $datepoint = $this->setTime(
+            (int) $this->format('H'),
+            (int) $this->format('i'),
+            (int) $this->format('s')
+        );
+
+        return new Period($datepoint, $datepoint->add(new DateInterval('PT1S')));
+    }
+
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint minute
+     *  - the duration is equal to 1 minute
+     */
+    public function getMinute(): Period
+    {
+        $datepoint = $this->setTime((int) $this->format('H'), (int) $this->format('i'), 0);
+
+        return new Period($datepoint, $datepoint->add(new DateInterval('PT1M')));
+    }
+
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint hour
+     *  - the duration is equal to 1 hour
+     */
+    public function getHour(): Period
+    {
+        $datepoint = $this->setTime((int) $this->format('H'), 0);
+
+        return new Period($datepoint, $datepoint->add(new DateInterval('PT1H')));
+    }
+
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint day
+     *  - the duration is equal to 1 day
+     */
+    public function getDay(): Period
     {
         $datepoint = $this->setTime(0, 0);
 
         return new Period($datepoint, $datepoint->add(new DateInterval('P1D')));
     }
 
-    public function extractIsoWeek(): Period
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint iso week day
+     *  - the duration is equal to 7 days
+     */
+    public function getIsoWeek(): Period
     {
         $startDate = $this
             ->setTime(0, 0)
@@ -75,7 +159,13 @@ final class Datepoint extends DateTimeImmutable
         return new Period($startDate, $startDate->add(new DateInterval('P7D')));
     }
 
-    public function extractMonth(): Period
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint month
+     *  - the duration is equal to 1 month
+     */
+    public function getMonth(): Period
     {
         $startDate = $this
             ->setTime(0, 0)
@@ -84,7 +174,13 @@ final class Datepoint extends DateTimeImmutable
         return new Period($startDate, $startDate->add(new DateInterval('P1M')));
     }
 
-    public function extractQuarter(): Period
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint quarter
+     *  - the duration is equal to 3 months
+     */
+    public function getQuarter(): Period
     {
         $startDate = $this
             ->setTime(0, 0)
@@ -93,7 +189,13 @@ final class Datepoint extends DateTimeImmutable
         return new Period($startDate, $startDate->add(new DateInterval('P3M')));
     }
 
-    public function extractSemester(): Period
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint semester
+     *  - the duration is equal to 6 months
+     */
+    public function getSemester(): Period
     {
         $startDate = $this
             ->setTime(0, 0)
@@ -102,7 +204,13 @@ final class Datepoint extends DateTimeImmutable
         return new Period($startDate, $startDate->add(new DateInterval('P6M')));
     }
 
-    public function extractYear(): Period
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint year
+     *  - the duration is equal to 1 year
+     */
+    public function getYear(): Period
     {
         $year = (int) $this->format('Y');
         $datepoint = $this->setTime(0, 0);
@@ -110,8 +218,13 @@ final class Datepoint extends DateTimeImmutable
         return new Period($datepoint->setDate($year, 1, 1), $datepoint->setDate(++$year, 1, 1));
     }
 
-
-    public function extractIsoYear(): Period
+    /**
+     * Returns a Period instance.
+     *
+     *  - the starting datepoint represents the beginning of the current datepoint iso year
+     *  - the duration is equal to 1 iso year
+     */
+    public function getIsoYear(): Period
     {
         $year = (int) $this->format('o');
         $datepoint = $this->setTime(0, 0);

--- a/src/Datepoint.php
+++ b/src/Datepoint.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace League\Period;
 
+use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use function filter_var;
+use function intdiv;
 use const FILTER_VALIDATE_INT;
 
 /**
@@ -40,14 +42,14 @@ final class Datepoint extends DateTimeImmutable
      *
      * @param mixed $datepoint a position in time
      */
-    public static function create($datepoint): DateTimeImmutable
+    public static function create($datepoint): self
     {
-        if ($datepoint instanceof DateTimeImmutable) {
+        if ($datepoint instanceof self) {
             return $datepoint;
         }
 
-        if ($datepoint instanceof DateTime) {
-            return self::createFromMutable($datepoint);
+        if ($datepoint instanceof DateTimeInterface) {
+            return new self($datepoint->format('Y-m-d H:i:s.u'), $datepoint->getTimezone());
         }
 
         if (false !== ($timestamp = filter_var($datepoint, FILTER_VALIDATE_INT))) {
@@ -55,5 +57,65 @@ final class Datepoint extends DateTimeImmutable
         }
 
         return new self($datepoint);
+    }
+
+    public function extractDay(): Period
+    {
+        $datepoint = $this->setTime(0, 0);
+
+        return new Period($datepoint, $datepoint->add(new DateInterval('P1D')));
+    }
+
+    public function extractIsoWeek(): Period
+    {
+        $startDate = $this
+            ->setTime(0, 0)
+            ->setISODate((int) $this->format('o'), (int) $this->format('W'), 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P7D')));
+    }
+
+    public function extractMonth(): Period
+    {
+        $startDate = $this
+            ->setTime(0, 0)
+            ->setDate((int) $this->format('Y'), (int) $this->format('n'), 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P1M')));
+    }
+
+    public function extractQuarter(): Period
+    {
+        $startDate = $this
+            ->setTime(0, 0)
+            ->setDate((int) $this->format('Y'), (intdiv((int) $this->format('n'), 3) * 3) + 1, 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P3M')));
+    }
+
+    public function extractSemester(): Period
+    {
+        $startDate = $this
+            ->setTime(0, 0)
+            ->setDate((int) $this->format('Y'), (intdiv((int) $this->format('n'), 6) * 6) + 1, 1);
+
+        return new Period($startDate, $startDate->add(new DateInterval('P6M')));
+    }
+
+    public function extractYear(): Period
+    {
+        $year = (int) $this->format('Y');
+        $datepoint = $this->setTime(0, 0);
+
+        return new Period($datepoint->setDate($year, 1, 1), $datepoint->setDate(++$year, 1, 1));
+    }
+
+
+    public function extractIsoYear(): Period
+    {
+        $year = (int) $this->format('o');
+        $datepoint = $this->setTime(0, 0);
+
+        return new Period($datepoint->setISODate($year, 1, 1), $datepoint->setISODate(++$year, 1, 1));
     }
 }

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -55,4 +55,25 @@ final class Duration extends DateInterval
 
         return self::createFromDateString($duration);
     }
+
+    /**
+     * @inheritdoc
+     *
+     * @param mixed $duration a date with relative parts
+     */
+    public static function createFromDateString($duration): self
+    {
+        $duration = parent::createFromDateString($duration);
+
+        $new = new self('PT0S');
+        $new->y = $duration->y;
+        $new->m = $duration->m;
+        $new->d = $duration->d;
+        $new->h = $duration->h;
+        $new->i = $duration->i;
+        $new->s = $duration->s;
+        $new->f = $duration->f;
+
+        return $new;
+    }
 }

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -14,13 +14,7 @@ declare(strict_types=1);
 namespace League\Period;
 
 use DateInterval;
-use TypeError;
 use function filter_var;
-use function get_class;
-use function gettype;
-use function is_object;
-use function is_string;
-use function sprintf;
 use const FILTER_VALIDATE_INT;
 
 /**
@@ -30,15 +24,8 @@ use const FILTER_VALIDATE_INT;
  * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @since   4.2.0
  */
-final class Duration
+final class Duration extends DateInterval
 {
-    /**
-     * @codeCoverageIgnore
-     */
-    private function __construct()
-    {
-    }
-
     /**
      * Returns a continuous portion of time between two datepoints expressed as a DateInterval object.
      *
@@ -63,16 +50,9 @@ final class Duration
         }
 
         if (false !== ($second = filter_var($duration, FILTER_VALIDATE_INT))) {
-            return new DateInterval('PT'.$second.'S');
+            return new self('PT'.$second.'S');
         }
 
-        if (is_string($duration)) {
-            return DateInterval::createFromDateString($duration);
-        }
-
-        throw new TypeError(sprintf(
-            'The duration must be expressed using an integer, a string, a DateInterval or a Period object %s given',
-            is_object($duration) ? get_class($duration) : gettype($duration)
-        ));
+        return self::createFromDateString($duration);
     }
 }

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com).
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\Period;
+
+use DateInterval;
+use TypeError;
+use function filter_var;
+use function get_class;
+use function gettype;
+use function is_object;
+use function is_string;
+use function sprintf;
+use const FILTER_VALIDATE_INT;
+
+/**
+ * League Period Duration.
+ *
+ * @package League.period
+ * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ * @since   4.2.0
+ */
+final class Duration
+{
+    /**
+     * @codeCoverageIgnore
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Returns a continuous portion of time between two datepoints expressed as a DateInterval object.
+     *
+     * The duration can be
+     * <ul>
+     * <li>an Period object</li>
+     * <li>a DateInterval object</li>
+     * <li>an integer interpreted as the duration expressed in seconds.</li>
+     * <li>a string parsable by DateInterval::createFromDateString</li>
+     * </ul>
+     *
+     * @param mixed $duration a continuous portion of time
+     */
+    public static function create($duration): DateInterval
+    {
+        if ($duration instanceof Period) {
+            return $duration->getDateInterval();
+        }
+
+        if ($duration instanceof DateInterval) {
+            return $duration;
+        }
+
+        if (false !== ($second = filter_var($duration, FILTER_VALIDATE_INT))) {
+            return new DateInterval('PT'.$second.'S');
+        }
+
+        if (is_string($duration)) {
+            return DateInterval::createFromDateString($duration);
+        }
+
+        throw new TypeError(sprintf(
+            'The duration must be expressed using an integer, a string, a DateInterval or a Period object %s given',
+            is_object($duration) ? get_class($duration) : gettype($duration)
+        ));
+    }
+}

--- a/src/Period.php
+++ b/src/Period.php
@@ -32,16 +32,16 @@ final class Period implements JsonSerializable
 {
     private const ISO8601_FORMAT = 'Y-m-d\TH:i:s.u\Z';
 
-    public const CALENDAR_YEAR = 'YEAR';
-    public const CALENDAR_ISOYEAR = 'ISOYEAR';
-    public const CALENDAR_SEMESTER = 'SEMESTER';
-    public const CALENDAR_QUARTER = 'QUARTER';
-    public const CALENDAR_MONTH = 'MONTH';
-    public const CALENDAR_ISOWEEK = 'ISOWEEK';
-    public const CALENDAR_DAY = 'DAY';
-    public const CALENDAR_HOUR = 'HOUR';
-    public const CALENDAR_MINUTE = 'MINUTE';
-    public const CALENDAR_SECOND = 'SECOND';
+    public const YEAR = 'YEAR';
+    public const ISOYEAR = 'ISOYEAR';
+    public const SEMESTER = 'SEMESTER';
+    public const QUARTER = 'QUARTER';
+    public const MONTH = 'MONTH';
+    public const ISOWEEK = 'ISOWEEK';
+    public const DAY = 'DAY';
+    public const HOUR = 'HOUR';
+    public const MINUTE = 'MINUTE';
+    public const SECOND = 'SECOND';
 
     /**
      * The starting included datepoint.
@@ -171,72 +171,26 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Creates new instance for a specific year, month, day and hour.
-     */
-    public static function fromHour(int $year, int $month = 1, int $day = 1, int $hour = 0): self
-    {
-        $startDate = (new DateTimeImmutable())->setDate($year, $month, $day)->setTime($hour, 0);
-
-        return new self($startDate, $startDate->add(new DateInterval('PT1H')));
-    }
-
-    /**
-     * Creates new instance for a specific year, month, day, hour and minute.
-     */
-    public static function fromMinute(int $year, int $month = 1, int $day = 1, int $hour = 0, int $minute = 0): self
-    {
-        $startDate = (new DateTimeImmutable())->setDate($year, $month, $day)->setTime($hour, $minute);
-
-        return new self($startDate, $startDate->add(new DateInterval('PT1M')));
-    }
-
-    /**
-     * Creates new instance for a specific year, month, day, hour, minute and second.
-     */
-    public static function fromSecond(
-        int $year,
-        int $month = 1,
-        int $day = 1,
-        int $hour = 0,
-        int $minute = 0,
-        int $second = 0
-    ): self {
-        $startDate = (new DateTimeImmutable())->setDate($year, $month, $day)->setTime($hour, $minute, $second);
-
-        return new self($startDate, $startDate->add(new DateInterval('PT1S')));
-    }
-
-    /**
-     * Creates new instance corresponding to a specific datepoint.
-     */
-    public static function fromDatepoint($datepoint): self
-    {
-        $datepoint = Datepoint::create($datepoint);
-
-        return new self($datepoint, $datepoint);
-    }
-
-    /**
      * Creates a new instance from a datepoint and a calendar reference.
      *
-     * The datepoint is contained or start the interval and the duration is
-     * equals to the calendar reference duration.
+     * The datepoint is contained or start the referenced calendar interval.
+     * The duration is equals to that of the calendar reference.
      */
     public static function fromCalendar($datepoint, string $calendar): self
     {
         $datepoint = Datepoint::create($datepoint);
         switch ($calendar) {
-            case self::CALENDAR_HOUR:
+            case self::HOUR:
                 $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0);
 
                 return new self($startDate, $startDate->add(new DateInterval('PT1H')));
 
-            case self::CALENDAR_MINUTE:
+            case self::MINUTE:
                 $startDate = $datepoint->setTime((int) $datepoint->format('H'), (int) $datepoint->format('i'));
 
                 return new self($startDate, $startDate->add(new DateInterval('PT1M')));
 
-            case self::CALENDAR_SECOND:
+            case self::SECOND:
                 $startDate = $datepoint->setTime(
                     (int) $datepoint->format('H'),
                     (int) $datepoint->format('i'),
@@ -245,45 +199,45 @@ final class Period implements JsonSerializable
 
                 return new self($startDate, $startDate->add(new DateInterval('PT1S')));
 
-            case self::CALENDAR_DAY:
+            case self::DAY:
                 $startDate = $datepoint->setTime(0, 0);
 
                 return new self($startDate, $startDate->add(new DateInterval('P1D')));
 
-            case self::CALENDAR_ISOWEEK:
+            case self::ISOWEEK:
                 $startDate = $datepoint
                     ->setTime(0, 0)
                     ->setISODate((int) $datepoint->format('o'), (int) $datepoint->format('W'), 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P7D')));
 
-            case self::CALENDAR_MONTH:
+            case self::MONTH:
                 $startDate = $datepoint
                     ->setTime(0, 0)
                     ->setDate((int) $datepoint->format('Y'), (int) $datepoint->format('n'), 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P1M')));
 
-            case self::CALENDAR_QUARTER:
+            case self::QUARTER:
                 $startDate = $datepoint
                     ->setTime(0, 0)
                     ->setDate((int) $datepoint->format('Y'), (intdiv((int) $datepoint->format('n'), 3) * 3) + 1, 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P3M')));
 
-            case self::CALENDAR_SEMESTER:
+            case self::SEMESTER:
                 $startDate = $datepoint
                     ->setTime(0, 0)
                     ->setDate((int) $datepoint->format('Y'), (intdiv((int) $datepoint->format('n'), 6) * 6) + 1, 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P6M')));
 
-            case self::CALENDAR_YEAR:
+            case self::YEAR:
                 $startDate = $datepoint->setTime(0, 0)->setDate((int) $datepoint->format('Y'), 1, 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P1Y')));
 
-            case self::CALENDAR_ISOYEAR:
+            case self::ISOYEAR:
                 $datepoint = $datepoint->setTime(0, 0);
                 $year = (int) $datepoint->format('o');
 

--- a/src/Period.php
+++ b/src/Period.php
@@ -178,67 +178,41 @@ final class Period implements JsonSerializable
      */
     public static function fromCalendar($datepoint, string $calendar): self
     {
-        $datepoint = Datepoint::create($datepoint);
+        $datepoint = Datepoint::create($datepoint)->setTime(0, 0);
         switch ($calendar) {
-            case self::HOUR:
-                $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0);
-
-                return new self($startDate, $startDate->add(new DateInterval('PT1H')));
-
-            case self::MINUTE:
-                $startDate = $datepoint->setTime((int) $datepoint->format('H'), (int) $datepoint->format('i'));
-
-                return new self($startDate, $startDate->add(new DateInterval('PT1M')));
-
-            case self::SECOND:
-                $startDate = $datepoint->setTime(
-                    (int) $datepoint->format('H'),
-                    (int) $datepoint->format('i'),
-                    (int) $datepoint->format('s')
-                );
-
-                return new self($startDate, $startDate->add(new DateInterval('PT1S')));
-
             case self::DAY:
-                $startDate = $datepoint->setTime(0, 0);
-
-                return new self($startDate, $startDate->add(new DateInterval('P1D')));
+                return new self($datepoint, $datepoint->add(new DateInterval('P1D')));
 
             case self::ISOWEEK:
                 $startDate = $datepoint
-                    ->setTime(0, 0)
                     ->setISODate((int) $datepoint->format('o'), (int) $datepoint->format('W'), 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P7D')));
 
             case self::MONTH:
                 $startDate = $datepoint
-                    ->setTime(0, 0)
                     ->setDate((int) $datepoint->format('Y'), (int) $datepoint->format('n'), 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P1M')));
 
             case self::QUARTER:
                 $startDate = $datepoint
-                    ->setTime(0, 0)
                     ->setDate((int) $datepoint->format('Y'), (intdiv((int) $datepoint->format('n'), 3) * 3) + 1, 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P3M')));
 
             case self::SEMESTER:
                 $startDate = $datepoint
-                    ->setTime(0, 0)
                     ->setDate((int) $datepoint->format('Y'), (intdiv((int) $datepoint->format('n'), 6) * 6) + 1, 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P6M')));
 
             case self::YEAR:
-                $startDate = $datepoint->setTime(0, 0)->setDate((int) $datepoint->format('Y'), 1, 1);
+                $startDate = $datepoint->setDate((int) $datepoint->format('Y'), 1, 1);
 
                 return new self($startDate, $startDate->add(new DateInterval('P1Y')));
 
             case self::ISOYEAR:
-                $datepoint = $datepoint->setTime(0, 0);
                 $year = (int) $datepoint->format('o');
 
                 return new self($datepoint->setISODate($year, 1), $datepoint->setISODate(++$year, 1));

--- a/src/Period.php
+++ b/src/Period.php
@@ -61,7 +61,7 @@ final class Period implements JsonSerializable
         if (!$datepoint instanceof DateTimeImmutable) {
             $datepoint = Datepoint::create($datepoint);
         }
-        
+
         return new self($datepoint, $datepoint->add(Duration::create($duration)));
     }
 

--- a/src/Period.php
+++ b/src/Period.php
@@ -208,9 +208,9 @@ final class Period implements JsonSerializable
                 return new self($startDate, $startDate->add(new DateInterval('P6M')));
 
             case self::YEAR:
-                $startDate = $datepoint->setDate((int) $datepoint->format('Y'), 1, 1);
+                $year = (int) $datepoint->format('Y');
 
-                return new self($startDate, $startDate->add(new DateInterval('P1Y')));
+                return new self($datepoint->setDate($year, 1, 1), $datepoint->setDate(++$year, 1, 1));
 
             case self::ISOYEAR:
                 $year = (int) $datepoint->format('o');

--- a/src/functions.php
+++ b/src/functions.php
@@ -114,7 +114,7 @@ function year($year_or_datepoint): Period
         return Period::fromYear($year_or_datepoint);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_YEAR);
+    return Period::fromCalendar($year_or_datepoint, Period::YEAR);
 }
 
 /**
@@ -134,7 +134,7 @@ function iso_year($year_or_datepoint): Period
         return Period::fromIsoYear($year_or_datepoint);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_ISOYEAR);
+    return Period::fromCalendar($year_or_datepoint, Period::ISOYEAR);
 }
 
 /**
@@ -154,7 +154,7 @@ function semester($year_or_datepoint, int $semester = 1): Period
         return Period::fromSemester($year_or_datepoint, $semester);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_SEMESTER);
+    return Period::fromCalendar($year_or_datepoint, Period::SEMESTER);
 }
 
 /**
@@ -174,7 +174,7 @@ function quarter($year_or_datepoint, int $quarter = 1): Period
         return Period::fromQuarter($year_or_datepoint, $quarter);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_QUARTER);
+    return Period::fromCalendar($year_or_datepoint, Period::QUARTER);
 }
 
 /**
@@ -194,7 +194,7 @@ function month($year_or_datepoint, int $month = 1): Period
         return Period::fromMonth($year_or_datepoint, $month);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_MONTH);
+    return Period::fromCalendar($year_or_datepoint, Period::MONTH);
 }
 
 /**
@@ -214,7 +214,7 @@ function iso_week($year_or_datepoint, int $week = 1): Period
         return Period::fromIsoWeek($year_or_datepoint, $week);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_ISOWEEK);
+    return Period::fromCalendar($year_or_datepoint, Period::ISOWEEK);
 }
 
 /**
@@ -237,7 +237,7 @@ function day($year_or_datepoint, int $month = 1, int $day = 1): Period
         return Period::fromDay($year_or_datepoint, $month, $day);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_DAY);
+    return Period::fromCalendar($year_or_datepoint, Period::DAY);
 }
 
 /**
@@ -246,7 +246,6 @@ function day($year_or_datepoint, int $month = 1, int $day = 1): Period
  * DEPRECATION WARNING! This function will be removed in the next major point release
  *
  * @deprecated deprecated since version 4.2
- * @see Period::fromHour
  * @see Period::fromCalendar
  *
  * The starting datepoint represents the beginning of the hour
@@ -257,10 +256,15 @@ function day($year_or_datepoint, int $month = 1, int $day = 1): Period
 function hour($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0): Period
 {
     if (is_int($year_or_datepoint)) {
-        return Period::fromHour($year_or_datepoint, $month, $day, $hour);
+        $startDate = (new DateTimeImmutable())
+            ->setDate($year_or_datepoint, $month, $day)
+            ->setTime($hour, 0)
+        ;
+
+        return Period::after($startDate, new DateInterval('PT1H'));
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_HOUR);
+    return Period::fromCalendar($year_or_datepoint, Period::HOUR);
 }
 
 /**
@@ -269,7 +273,6 @@ function hour($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0): 
  * DEPRECATION WARNING! This function will be removed in the next major point release
  *
  * @deprecated deprecated since version 4.2
- * @see Period::fromMinute
  * @see Period::fromCalendar
  *
  * The starting datepoint represents the beginning of the minute
@@ -280,10 +283,15 @@ function hour($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0): 
 function minute($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0, int $minute = 0): Period
 {
     if (is_int($year_or_datepoint)) {
-        return Period::fromMinute($year_or_datepoint, $month, $day, $hour, $minute);
+        $startDate = (new DateTimeImmutable())
+            ->setDate($year_or_datepoint, $month, $day)
+            ->setTime($hour, $minute)
+        ;
+
+        return Period::after($startDate, new DateInterval('PT1M'));
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_MINUTE);
+    return Period::fromCalendar($year_or_datepoint, Period::MINUTE);
 }
 
 /**
@@ -292,7 +300,6 @@ function minute($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0,
  * DEPRECATION WARNING! This function will be removed in the next major point release
  *
  * @deprecated deprecated since version 4.2
- * @see Period::fromSecond
  * @see Period::fromCalendar
  *
  * The starting datepoint represents the beginning of the second
@@ -309,10 +316,15 @@ function second(
     int $second = 0
 ): Period {
     if (is_int($year_or_datepoint)) {
-        return Period::fromSecond($year_or_datepoint, $month, $day, $hour, $minute, $second);
+        $startDate = (new DateTimeImmutable())
+            ->setDate($year_or_datepoint, $month, $day)
+            ->setTime($hour, $minute, $second)
+        ;
+
+        return Period::after($startDate, new DateInterval('PT1S'));
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_SECOND);
+    return Period::fromCalendar($year_or_datepoint, Period::SECOND);
 }
 
 /**
@@ -330,12 +342,10 @@ function instant(
     int $microsecond = 0
 ): Period {
     if (is_int($year_or_datepoint)) {
-        $datepoint = (new DateTimeImmutable())
+        $year_or_datepoint = (new DateTimeImmutable())
             ->setDate($year_or_datepoint, $month, $day)
             ->setTime($hour, $minute, $second, $microsecond);
-
-        return new Period($datepoint, $datepoint);
     }
 
-    return Period::fromDatepoint($year_or_datepoint);
+    return new Period($year_or_datepoint, $year_or_datepoint);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -118,7 +118,7 @@ function year($year_or_datepoint): Period
         return Period::fromYear($year_or_datepoint);
     }
 
-    return Datepoint::create($year_or_datepoint)->extractYear();
+    return Datepoint::create($year_or_datepoint)->getYear();
 }
 
 /**
@@ -138,7 +138,7 @@ function iso_year($year_or_datepoint): Period
         return Period::fromIsoYear($year_or_datepoint);
     }
 
-    return Datepoint::create($year_or_datepoint)->extractIsoYear();
+    return Datepoint::create($year_or_datepoint)->getIsoYear();
 }
 
 /**
@@ -158,7 +158,7 @@ function semester($year_or_datepoint, int $semester = 1): Period
         return Period::fromSemester($year_or_datepoint, $semester);
     }
 
-    return Datepoint::create($year_or_datepoint)->extractSemester();
+    return Datepoint::create($year_or_datepoint)->getSemester();
 }
 
 /**
@@ -178,7 +178,7 @@ function quarter($year_or_datepoint, int $quarter = 1): Period
         return Period::fromQuarter($year_or_datepoint, $quarter);
     }
 
-    return Datepoint::create($year_or_datepoint)->extractQuarter();
+    return Datepoint::create($year_or_datepoint)->getQuarter();
 }
 
 /**
@@ -198,7 +198,7 @@ function month($year_or_datepoint, int $month = 1): Period
         return Period::fromMonth($year_or_datepoint, $month);
     }
 
-    return Datepoint::create($year_or_datepoint)->extractMonth();
+    return Datepoint::create($year_or_datepoint)->getMonth();
 }
 
 /**
@@ -218,7 +218,7 @@ function iso_week($year_or_datepoint, int $week = 1): Period
         return Period::fromIsoWeek($year_or_datepoint, $week);
     }
 
-    return Datepoint::create($year_or_datepoint)->extractIsoWeek();
+    return Datepoint::create($year_or_datepoint)->getIsoWeek();
 }
 
 /**
@@ -241,7 +241,7 @@ function day($year_or_datepoint, int $month = 1, int $day = 1): Period
         return Period::fromDay($year_or_datepoint, $month, $day);
     }
 
-    return Datepoint::create($year_or_datepoint)->extractDay();
+    return Datepoint::create($year_or_datepoint)->getDay();
 }
 
 /**
@@ -268,10 +268,7 @@ function hour($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0): 
         return Period::after($startDate, new DateInterval('PT1H'));
     }
 
-    $datepoint = Datepoint::create($year_or_datepoint);
-    $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0);
-
-    return Period::after($startDate, new DateInterval('PT1H'));
+    return Datepoint::create($year_or_datepoint)->getHour();
 }
 
 /**
@@ -298,14 +295,7 @@ function minute($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0,
         return Period::after($startDate, new DateInterval('PT1M'));
     }
 
-    $datepoint = Datepoint::create($year_or_datepoint);
-    $startDate = $datepoint->setTime(
-        (int) $datepoint->format('H'),
-        (int) $datepoint->format('i'),
-        0
-    );
-
-    return Period::after($startDate, new DateInterval('PT1M'));
+    return Datepoint::create($year_or_datepoint)->getMinute();
 }
 
 /**
@@ -338,14 +328,7 @@ function second(
         return Period::after($startDate, new DateInterval('PT1S'));
     }
 
-    $datepoint = Datepoint::create($year_or_datepoint);
-    $startDate = $datepoint->setTime(
-        (int) $datepoint->format('H'),
-        (int) $datepoint->format('i'),
-        (int) $datepoint->format('s')
-    );
-
-    return Period::after($startDate, new DateInterval('PT1S'));
+    return Datepoint::create($year_or_datepoint)->getSecond();
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -28,6 +28,10 @@ use function is_int;
  */
 function datepoint($datepoint): DateTimeImmutable
 {
+    if ($datepoint instanceof DateTimeImmutable) {
+        return $datepoint;
+    }
+
     return Datepoint::create($datepoint);
 }
 
@@ -114,7 +118,7 @@ function year($year_or_datepoint): Period
         return Period::fromYear($year_or_datepoint);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::YEAR);
+    return Datepoint::create($year_or_datepoint)->extractYear();
 }
 
 /**
@@ -134,7 +138,7 @@ function iso_year($year_or_datepoint): Period
         return Period::fromIsoYear($year_or_datepoint);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::ISOYEAR);
+    return Datepoint::create($year_or_datepoint)->extractIsoYear();
 }
 
 /**
@@ -154,7 +158,7 @@ function semester($year_or_datepoint, int $semester = 1): Period
         return Period::fromSemester($year_or_datepoint, $semester);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::SEMESTER);
+    return Datepoint::create($year_or_datepoint)->extractSemester();
 }
 
 /**
@@ -174,7 +178,7 @@ function quarter($year_or_datepoint, int $quarter = 1): Period
         return Period::fromQuarter($year_or_datepoint, $quarter);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::QUARTER);
+    return Datepoint::create($year_or_datepoint)->extractQuarter();
 }
 
 /**
@@ -194,7 +198,7 @@ function month($year_or_datepoint, int $month = 1): Period
         return Period::fromMonth($year_or_datepoint, $month);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::MONTH);
+    return Datepoint::create($year_or_datepoint)->extractMonth();
 }
 
 /**
@@ -214,7 +218,7 @@ function iso_week($year_or_datepoint, int $week = 1): Period
         return Period::fromIsoWeek($year_or_datepoint, $week);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::ISOWEEK);
+    return Datepoint::create($year_or_datepoint)->extractIsoWeek();
 }
 
 /**
@@ -237,7 +241,7 @@ function day($year_or_datepoint, int $month = 1, int $day = 1): Period
         return Period::fromDay($year_or_datepoint, $month, $day);
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::DAY);
+    return Datepoint::create($year_or_datepoint)->extractDay();
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -264,7 +264,10 @@ function hour($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0): 
         return Period::after($startDate, new DateInterval('PT1H'));
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::HOUR);
+    $datepoint = Datepoint::create($year_or_datepoint);
+    $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0);
+
+    return Period::after($startDate, new DateInterval('PT1H'));
 }
 
 /**
@@ -291,7 +294,14 @@ function minute($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0,
         return Period::after($startDate, new DateInterval('PT1M'));
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::MINUTE);
+    $datepoint = Datepoint::create($year_or_datepoint);
+    $startDate = $datepoint->setTime(
+        (int) $datepoint->format('H'),
+        (int) $datepoint->format('i'),
+        0
+    );
+
+    return Period::after($startDate, new DateInterval('PT1M'));
 }
 
 /**
@@ -324,7 +334,14 @@ function second(
         return Period::after($startDate, new DateInterval('PT1S'));
     }
 
-    return Period::fromCalendar($year_or_datepoint, Period::SECOND);
+    $datepoint = Datepoint::create($year_or_datepoint);
+    $startDate = $datepoint->setTime(
+        (int) $datepoint->format('H'),
+        (int) $datepoint->format('i'),
+        (int) $datepoint->format('s')
+    );
+
+    return Period::after($startDate, new DateInterval('PT1S'));
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -15,256 +15,216 @@ namespace League\Period;
 
 use DateInterval;
 use DatePeriod;
-use DateTime;
 use DateTimeImmutable;
-use DateTimeInterface;
-use TypeError;
-use function filter_var;
-use function get_class;
-use function gettype;
-use function intdiv;
 use function is_int;
-use function is_object;
-use function is_string;
-use function sprintf;
-use const FILTER_VALIDATE_INT;
 
 /**
  * Returns a DateTimeImmutable object.
  *
- * A datepoint can be
- * <ul>
- * <li>a DateTimeInterface object
- * <li>a integer interpreted as a timestamp
- * <li>a string parsable by DateTime::__construct
- * </ul>
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Datepoint::create
  */
 function datepoint($datepoint): DateTimeImmutable
 {
-    if ($datepoint instanceof DateTimeImmutable) {
-        return $datepoint;
-    }
-
-    if ($datepoint instanceof DateTime) {
-        return DateTimeImmutable::createFromMutable($datepoint);
-    }
-
-    if (false !== ($timestamp = filter_var($datepoint, FILTER_VALIDATE_INT))) {
-        return new DateTimeImmutable('@'.$timestamp);
-    }
-
-    if (is_string($datepoint)) {
-        return new DateTimeImmutable($datepoint);
-    }
-
-    throw new TypeError(sprintf(
-        'The datepoint must be expressed using an integer, a string or a DateTimeInterface object %s given',
-        is_object($datepoint) ? get_class($datepoint) : gettype($datepoint)
-    ));
+    return Datepoint::create($datepoint);
 }
 
 /**
  * Returns a DateInval object.
  *
- * The duration can be
- * <ul>
- * <li>an Period object</li>
- * <li>a DateInterval object</li>
- * <li>an integer interpreted as the duration expressed in seconds.</li>
- * <li>a string parsable by DateInterval::createFromDateString</li>
- * </ul>
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Duration::create
  */
 function duration($duration): DateInterval
 {
-    if ($duration instanceof Period) {
-        return $duration->getDateInterval();
-    }
-
-    if ($duration instanceof DateInterval) {
-        return $duration;
-    }
-
-    if (false !== ($second = filter_var($duration, FILTER_VALIDATE_INT))) {
-        return new DateInterval('PT'.$second.'S');
-    }
-
-    if (is_string($duration)) {
-        return DateInterval::createFromDateString($duration);
-    }
-
-    throw new TypeError(sprintf(
-        'The duration must be expressed using an integer, a string, a DateInterval or a Period object %s given',
-        is_object($duration) ? get_class($duration) : gettype($duration)
-    ));
+    return Duration::create($duration);
 }
 
 /**
  * Creates new instance from a starting point and an interval.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::after
  */
 function interval_after($datepoint, $duration): Period
 {
-    $datepoint = datepoint($datepoint);
-    $duration = duration($duration);
-
-    return new Period($datepoint, $datepoint->add($duration));
+    return Period::after($datepoint, $duration);
 }
 
 /**
  * Creates new instance from a ending excluded datepoint and an interval.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::before
  */
 function interval_before($datepoint, $duration): Period
 {
-    $datepoint = datepoint($datepoint);
-    $duration = duration($duration);
-
-    return new Period($datepoint->sub($duration), $datepoint);
+    return Period::before($datepoint, $duration);
 }
 
 /**
  * Creates new instance where the given duration is simultaneously
  * substracted from and added to the datepoint.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::around
  */
 function interval_around($datepoint, $duration): Period
 {
-    $datepoint = datepoint($datepoint);
-    $duration = duration($duration);
-
-    return new Period($datepoint->sub($duration), $datepoint->add($duration));
+    return Period::around($datepoint, $duration);
 }
 
 /**
  * Creates new instance from a DatePeriod.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromDatePeriod
  */
 function interval_from_dateperiod(DatePeriod $datePeriod): Period
 {
-    return new Period($datePeriod->getStartDate(), $datePeriod->getEndDate());
+    return Period::fromDatePeriod($datePeriod);
 }
 
 /**
  * Creates new instance for a specific year.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromYear
+ * @see Period::fromCalendar
  *
  * @param mixed $year_or_datepoint a year as an int or a datepoint
  */
 function year($year_or_datepoint): Period
 {
     if (is_int($year_or_datepoint)) {
-        $startDate = (new DateTimeImmutable())->setDate($year_or_datepoint, 1, 1)->setTime(0, 0);
-
-        return new Period($startDate, $startDate->add(new DateInterval('P1Y')));
+        return Period::fromYear($year_or_datepoint);
     }
 
-    $datepoint = datepoint($year_or_datepoint);
-    $startDate = $datepoint->setDate((int) $datepoint->format('Y'), 1, 1)->setTime(0, 0);
-
-    return new Period($startDate, $startDate->add(new DateInterval('P1Y')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_YEAR);
 }
 
 /**
  * Creates new instance for a specific ISO year.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromIsoYear
+ * @see Period::fromCalendar
  *
  * @param mixed $year_or_datepoint an iso year as an int or a datepoint
  */
 function iso_year($year_or_datepoint): Period
 {
     if (is_int($year_or_datepoint)) {
-        return new Period(
-            (new DateTimeImmutable())->setISODate($year_or_datepoint, 1)->setTime(0, 0),
-            (new DateTimeImmutable())->setISODate(++$year_or_datepoint, 1)->setTime(0, 0)
-        );
+        return Period::fromIsoYear($year_or_datepoint);
     }
 
-    $datepoint = datepoint($year_or_datepoint)->setTime(0, 0);
-    $iso_year = (int) $datepoint->format('o');
-
-    return new Period($datepoint->setISODate($iso_year, 1), $datepoint->setISODate(++$iso_year, 1));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_ISOYEAR);
 }
 
 /**
  * Creates new instance for a specific semester in a given year.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromSemester
+ * @see Period::fromCalendar
  *
  * @param mixed $year_or_datepoint a year as an int or a datepoint
  */
 function semester($year_or_datepoint, int $semester = 1): Period
 {
     if (is_int($year_or_datepoint)) {
-        $month = (($semester - 1) * 6) + 1;
-        $startDate = (new DateTimeImmutable())->setDate($year_or_datepoint, $month, 1)->setTime(0, 0);
-
-        return new Period($startDate, $startDate->add(new DateInterval('P6M')));
+        return Period::fromSemester($year_or_datepoint, $semester);
     }
 
-    $datepoint = datepoint($year_or_datepoint);
-    $year = (int) $datepoint->format('Y');
-    $month = (intdiv((int) $datepoint->format('n'), 6) * 6) + 1;
-    $startDate = $datepoint->setDate($year, $month, 1)->setTime(0, 0);
-
-    return new Period($startDate, $startDate->add(new DateInterval('P6M')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_SEMESTER);
 }
 
 /**
  * Creates new instance for a specific quarter in a given year.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromQuarter
+ * @see Period::fromCalendar
  *
  * @param mixed $year_or_datepoint an iso year as an int or a datepoint
  */
 function quarter($year_or_datepoint, int $quarter = 1): Period
 {
     if (is_int($year_or_datepoint)) {
-        $month = (($quarter - 1) * 3) + 1;
-        $startDate = (new DateTimeImmutable())->setDate($year_or_datepoint, $month, 1)->setTime(0, 0);
-
-        return new Period($startDate, $startDate->add(new DateInterval('P3M')));
+        return Period::fromQuarter($year_or_datepoint, $quarter);
     }
 
-    $datepoint = datepoint($year_or_datepoint);
-    $year = (int) $datepoint->format('Y');
-    $month = (intdiv((int) $datepoint->format('n'), 3) * 3) + 1;
-    $startDate = $datepoint->setDate($year, $month, 1)->setTime(0, 0);
-
-    return new Period($startDate, $startDate->add(new DateInterval('P3M')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_QUARTER);
 }
 
 /**
  * Creates new instance for a specific year and month.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromMonth
+ * @see Period::fromCalendar
  *
  * @param mixed $year_or_datepoint a year as an int or a datepoint
  */
 function month($year_or_datepoint, int $month = 1): Period
 {
     if (is_int($year_or_datepoint)) {
-        $startDate = (new DateTimeImmutable())->setDate($year_or_datepoint, $month, 1)->setTime(0, 0);
-
-        return new Period($startDate, $startDate->add(new DateInterval('P1M')));
+        return Period::fromMonth($year_or_datepoint, $month);
     }
 
-    $datepoint = datepoint($year_or_datepoint);
-    $startDate = $datepoint
-        ->setDate((int) $datepoint->format('Y'), (int) $datepoint->format('n'), 1)
-        ->setTime(0, 0);
-
-    return new Period($startDate, $startDate->add(new DateInterval('P1M')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_MONTH);
 }
 
 /**
  * Creates new instance for a specific ISO8601 week.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromIsoWeek
+ * @see Period::fromCalendar
  *
  * @param mixed $year_or_datepoint an iso year as an int or a datepoint
  */
 function iso_week($year_or_datepoint, int $week = 1): Period
 {
     if (is_int($year_or_datepoint)) {
-        $startDate = (new DateTimeImmutable())->setISODate($year_or_datepoint, $week, 1)->setTime(0, 0);
-
-        return new Period($startDate, $startDate->add(new DateInterval('P7D')));
+        return Period::fromIsoWeek($year_or_datepoint, $week);
     }
 
-    $datepoint = datepoint($year_or_datepoint)->setTime(0, 0);
-    $startDate = $datepoint->setISODate((int) $datepoint->format('o'), (int) $datepoint->format('W'), 1);
-
-    return new Period($startDate, $startDate->add(new DateInterval('P7D')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_ISOWEEK);
 }
 
 /**
  * Creates new instance for a specific date.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromIsoWeek
+ * @see Period::fromCalendar
  *
  * The date is truncated so that the time range starts at midnight
  * according to the date timezone and last a full day.
@@ -274,18 +234,20 @@ function iso_week($year_or_datepoint, int $week = 1): Period
 function day($year_or_datepoint, int $month = 1, int $day = 1): Period
 {
     if (is_int($year_or_datepoint)) {
-        $startDate = (new DateTimeImmutable())->setDate($year_or_datepoint, $month, $day)->setTime(0, 0);
-
-        return new Period($startDate, $startDate->add(new DateInterval('P1D')));
+        return Period::fromDay($year_or_datepoint, $month, $day);
     }
 
-    $startDate = datepoint($year_or_datepoint)->setTime(0, 0);
-
-    return new Period($startDate, $startDate->add(new DateInterval('P1D')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_DAY);
 }
 
 /**
  * Creates new instance for a specific date and hour.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromHour
+ * @see Period::fromCalendar
  *
  * The starting datepoint represents the beginning of the hour
  * The interval is equal to 1 hour
@@ -295,19 +257,20 @@ function day($year_or_datepoint, int $month = 1, int $day = 1): Period
 function hour($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0): Period
 {
     if (is_int($year_or_datepoint)) {
-        $startDate = (new DateTimeImmutable())->setDate($year_or_datepoint, $month, $day)->setTime($hour, 0);
-
-        return new Period($startDate, $startDate->add(new DateInterval('PT1H')));
+        return Period::fromHour($year_or_datepoint, $month, $day, $hour);
     }
 
-    $datepoint = datepoint($year_or_datepoint);
-    $startDate = $datepoint->setTime((int) $datepoint->format('H'), 0);
-
-    return new Period($startDate, $startDate->add(new DateInterval('PT1H')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_HOUR);
 }
 
 /**
  * Creates new instance for a specific date, hour and minute.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromMinute
+ * @see Period::fromCalendar
  *
  * The starting datepoint represents the beginning of the minute
  * The interval is equal to 1 minute
@@ -317,19 +280,20 @@ function hour($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0): 
 function minute($year_or_datepoint, int $month = 1, int $day = 1, int $hour = 0, int $minute = 0): Period
 {
     if (is_int($year_or_datepoint)) {
-        $startDate = (new DateTimeImmutable())->setDate($year_or_datepoint, $month, $day)->setTime($hour, $minute);
-
-        return new Period($startDate, $startDate->add(new DateInterval('PT1M')));
+        return Period::fromMinute($year_or_datepoint, $month, $day, $hour, $minute);
     }
 
-    $datepoint = datepoint($year_or_datepoint);
-    $startDate = $datepoint->setTime((int) $datepoint->format('H'), (int) $datepoint->format('i'));
-
-    return new Period($startDate, $startDate->add(new DateInterval('PT1M')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_MINUTE);
 }
 
 /**
  * Creates new instance for a specific date, hour, minute and second.
+ *
+ * DEPRECATION WARNING! This function will be removed in the next major point release
+ *
+ * @deprecated deprecated since version 4.2
+ * @see Period::fromSecond
+ * @see Period::fromCalendar
  *
  * The starting datepoint represents the beginning of the second
  * The interval is equal to 1 second
@@ -345,21 +309,10 @@ function second(
     int $second = 0
 ): Period {
     if (is_int($year_or_datepoint)) {
-        $startDate = (new DateTimeImmutable())
-            ->setDate($year_or_datepoint, $month, $day)
-            ->setTime($hour, $minute, $second);
-
-        return new Period($startDate, $startDate->add(new DateInterval('PT1S')));
+        return Period::fromSecond($year_or_datepoint, $month, $day, $hour, $minute, $second);
     }
 
-    $datepoint = datepoint($year_or_datepoint);
-    $startDate = $datepoint->setTime(
-        (int) $datepoint->format('H'),
-        (int) $datepoint->format('i'),
-        (int) $datepoint->format('s')
-    );
-
-    return new Period($startDate, $startDate->add(new DateInterval('PT1S')));
+    return Period::fromCalendar($year_or_datepoint, Period::CALENDAR_SECOND);
 }
 
 /**
@@ -384,7 +337,5 @@ function instant(
         return new Period($datepoint, $datepoint);
     }
 
-    $datepoint = datepoint($year_or_datepoint);
-
-    return new Period($datepoint, $datepoint);
+    return Period::fromDatepoint($year_or_datepoint);
 }

--- a/tests/DatepointTest.php
+++ b/tests/DatepointTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com).
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period;
+
+use DateTime;
+use DateTimeImmutable;
+use League\Period\Datepoint;
+use PHPUnit\Framework\TestCase;
+
+class DatepointTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $timezone;
+
+    public function setUp(): void
+    {
+        $this->timezone = date_default_timezone_get();
+    }
+
+    public function tearDown(): void
+    {
+        date_default_timezone_set($this->timezone);
+    }
+
+    public function testCreateFromFormat(): void
+    {
+        self::assertInstanceOf(Datepoint::class, Datepoint::createFromFormat('Y-m-d', '2018-12-01'));
+        self::assertFalse(Datepoint::createFromFormat('Y-m-d', 'foobar'));
+    }
+
+    public function testCreateFromMutable(): void
+    {
+        $date = new DateTime();
+        self::assertTrue(Datepoint::createFromMutable($date) == DateTimeImmutable::createFromMutable($date));
+    }
+}

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com).
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period;
+
+use League\Period\Duration;
+use PHPUnit\Framework\TestCase;
+
+class DurationTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $timezone;
+
+    public function setUp(): void
+    {
+        $this->timezone = date_default_timezone_get();
+    }
+
+    public function tearDown(): void
+    {
+        date_default_timezone_set($this->timezone);
+    }
+
+    public function testCreateFromDateString(): void
+    {
+        $duration = Duration::createFromDateString('+1 DAY');
+        self::assertSame(1, $duration->d);
+        self::assertFalse($duration->days);
+        $altduration = Duration::createFromDateString('foobar');
+        self::assertSame(0, $altduration->s);
+    }
+}

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -17,9 +17,11 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Exception as PhpException;
+use League\Period\Duration;
 use League\Period\Exception;
 use PHPUnit\Framework\TestCase;
 use TypeError;
+use function get_object_vars;
 use function League\Period\datepoint;
 use function League\Period\day;
 use function League\Period\duration;
@@ -83,11 +85,12 @@ class FunctionTest extends TestCase
     /**
      * @dataProvider durationProvider
      *
+     * @param mixed                   $expected DateInterval object
      * @param int|DateInterval|string $duration
      */
-    public function testDuration(DateInterval $expected, $duration): void
+    public function testDuration($expected, $duration): void
     {
-        self::assertEquals($expected, duration($duration));
+        self::assertEquals(get_object_vars($expected), get_object_vars(duration($duration)));
     }
 
     public function durationProvider(): array
@@ -98,7 +101,7 @@ class FunctionTest extends TestCase
                 'input' => new DateInterval('P1D'),
             ],
             'string' => [
-                'expected' => new DateInterval('P1D'),
+                'expected' => new Duration('P1D'),
                 'input' => '+1 DAY',
             ],
             'int' => [

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -331,8 +331,6 @@ class FunctionTest extends TestCase
         self::assertEquals(new DateTimeImmutable('2008-07-02T00:00:00+08:00'), $period->getEndDate());
         self::assertEquals('+08:00', $period->getStartDate()->format('P'));
         self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
     public function testAlternateDay(): void
@@ -356,8 +354,6 @@ class FunctionTest extends TestCase
         self::assertEquals(new DateTimeImmutable('2008-07-01T23:00:00+08:00'), $period->getEndDate());
         self::assertEquals('+08:00', $period->getStartDate()->format('P'));
         self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
     public function testAlternateHour(): void
@@ -383,8 +379,6 @@ class FunctionTest extends TestCase
         self::assertEquals(new DateTimeImmutable('2008-07-01T22:36:00+08:00'), $period->getEndDate());
         self::assertEquals('+08:00', $period->getStartDate()->format('P'));
         self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
     public function testAlternateMinute(): void
@@ -413,8 +407,6 @@ class FunctionTest extends TestCase
         self::assertEquals(new DateTimeImmutable('2008-07-01T22:35:18+08:00'), $period->getEndDate());
         self::assertEquals('+08:00', $period->getStartDate()->format('P'));
         self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
     public function testAlternateSecond(): void
@@ -442,8 +434,6 @@ class FunctionTest extends TestCase
         self::assertEquals($today, $period->getEndDate());
         self::assertEquals('+08:00', $period->getStartDate()->format('P'));
         self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
         self::assertEquals(new DateInterval('P0D'), $period->getDateInterval());
     }
 
@@ -482,8 +472,6 @@ class FunctionTest extends TestCase
         self::assertEquals(new DateTimeImmutable('2008-08-01T00:00:00+08:00'), $period->getEndDate());
         self::assertEquals('+08:00', $period->getStartDate()->format('P'));
         self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 
     public function testYearWithDateTimeInterface(): void
@@ -494,7 +482,5 @@ class FunctionTest extends TestCase
         self::assertEquals(new DateTimeImmutable('2009-01-01T00:00:00+08:00'), $period->getEndDate());
         self::assertEquals('+08:00', $period->getStartDate()->format('P'));
         self::assertEquals('+08:00', $period->getEndDate()->format('P'));
-        self::assertInstanceOf(ExtendedDate::class, $period->getStartDate());
-        self::assertInstanceOf(ExtendedDate::class, $period->getEndDate());
     }
 }

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -878,4 +878,10 @@ class PeriodTest extends TestCase
         }
         self::assertSame(10, $i);
     }
+
+    public function testFromCalendarFails(): void
+    {
+        self::expectException(Exception::class);
+        Period::fromCalendar('now', 'foobar');
+    }
 }

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -878,10 +878,4 @@ class PeriodTest extends TestCase
         }
         self::assertSame(10, $i);
     }
-
-    public function testFromCalendarFails(): void
-    {
-        self::expectException(Exception::class);
-        Period::fromCalendar('now', 'foobar');
-    }
 }


### PR DESCRIPTION
Currently when using the namespaced functions of League\Period, the signature are not well understood and one as to go back and forth between usage and documentation to really understand the function returned value. 

To improve the public API this PR re-introduce named constructors on the `Period` object and adds 2 new classes, `League\Period\Datepoint` and `League\Period\Duration` and deprecated all namespace functions in favor of the new system.

here's a simple example, currently we have this:

```php
use function League\Period\day;

day('2018-12-15')->format('Y-m-d'); // [2018-12-15, 2018-12-16)
day(2018, 12, 15)->format('Y-m-d'); // [2018-12-15, 2018-12-16)
day('2018', 12, 15)->format('Y-m-d'); // [1970-01-01, 1970-01-02)
```

With the new improve API we will have this

```php
use League\Period\Period;
use League\Period\Datepoint;

Datepoint::create('2018-12-15')->getDay()->format('Y-m-d'); // [2018-12-15, 2018-12-16)
Period::fromDay(2018, 12, 15)->format('Y-m-d'); // [2018-12-15, 2018-12-16)
Period::fromDay('2018', 12, 15->format('Y-m-d'); // [2018-12-15, 2018-12-16)
Period::fromDay('2018', 12, 15); // will throw a TypeError with strict_types=1
```

Of note, we are not re-using v3.x named constructor names because the new named constructor do not behave as there v3.x contrepart.

in v3

```php
Period::createFromMonth(2018, 14); //will throw because 14 > 12
```
in v4

```php
Period::fromMonth(2018, 14)->format('Y-m-d'); // [2019-02-01, 2019-03-01)
```
In v4 we use `DateTimeImmutable` overflow mechanism to return a `Period` instance.

The following classes and methods are added:

- `League\Period\Datepoint`
- `League\Period\Duration`
- `Period::fromIsoYear`
- `Period::fromYear`
- `Period::fromSemester`
- `Period::fromQuarter`
- `Period::fromMonth`
- `Period::fromIsoWeek`
- `Period::fromDay`
- `Period::after`
- `Period::before`
- `Period::around`
- `Period::fromDatePeriod`

The following functions are deprecated:

- `League\Period\datepoint`
- `League\Period\duration`
- `League\Period\year`
- `League\Period\semester`
- `League\Period\quarter`
- `League\Period\month`
- `League\Period\day`
- `League\Period\hour`
- `League\Period\minute`
- `League\Period\second`
- `League\Period\instant`
- `League\Period\iso_year`
- `League\Period\iso_week`
- `League\Period\interval_after`
- `League\Period\interval_before`
- `League\Period\interval_around`
- `League\Period\interval_from_dateperiod`