### PR TITLE
Adding Boundary support to the Period package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       env:
         - COLLECT_COVERAGE=true
         - IGNORE_PLATFORMS=false
-        - RUN_PHPSTAN=false
+        - RUN_PHPSTAN=true
         - RUN_INFECTION=false
         - VALIDATE_CODING_STYLE=false
     - php: 7.2
@@ -30,14 +30,14 @@ matrix:
       env:
         - COLLECT_COVERAGE=true
         - IGNORE_PLATFORMS=true
-        - RUN_PHPSTAN=false
+        - RUN_PHPSTAN=true
         - RUN_INFECTION=false
         - VALIDATE_CODING_STYLE=false
     - php: nightly
       env:
         - COLLECT_COVERAGE=false
         - IGNORE_PLATFORMS=true
-        - RUN_PHPSTAN=false
+        - RUN_PHPSTAN=true
         - RUN_INFECTION=false
         - VALIDATE_CODING_STYLE=false
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ All Notable changes to `Period` will be documented in this file
     - `Period::borderOnEnd`
     - `Period::isDuring`
     - `Period::starts`
-    - `Period::finishes`
-- `Sequence::getUnions`
+    - `Period::ends`
+- `Sequence::unions`
+- `Sequence::intersections`
+- `Sequence::gaps`
+- `Sequence::boundaries`
 
 ### Fixed
 
@@ -36,7 +39,9 @@ All Notable changes to `Period` will be documented in this file
 
 ### Deprecated
 
-- None
+- `Sequence::getIntersections`
+- `Sequence::getGaps`
+- `Sequence::getBoundaries`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ All Notable changes to `Period` will be documented in this file
     - `Period::around` adds the `$boundaryType` argument;
     - `Period::fromDatePeriod` adds the `$boundaryType` argument;
 - Added missing [Allen's Algebra intervals](https://www.ics.uci.edu/~alspaugh/cls/shr/allen.html)
-    - `Period::meets`
-    - `Period::metBy`
+    - `Period::borderOnStart`
+    - `Period::borderOnEnd`
     - `Period::isDuring`
     - `Period::starts`
     - `Period::finishes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ All Notable changes to `Period` will be documented in this file
     - `Period::bordersOnStart`
     - `Period::bordersOnEnd`
     - `Period::isDuring`
-    - `Period::starts`
-    - `Period::ends`
+    - `Period::startsBy`
+    - `Period::endsBy`
 - `Sequence::unions`
 - `Sequence::intersections`
 - `Sequence::gaps`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All Notable changes to `Period` will be documented in this file
 - `Period::meets`
 - `Period::metBy`
 - `Period::isDuring`
+- `Period::starts`
+- `Period::finishes`
 - `Period::after` supports the `$boundaryType` argument;
 - `Period::before` supports the `$boundaryType` argument;
 - `Period::around` supports the `$boundaryType` argument;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,28 @@ All Notable changes to `Period` will be documented in this file
 
 ### Added
 
-- Added support for the boundary type on all relations methods
-- `Period::EXCLUDE_START_INCLUDE_END`
-- `Period::EXCLUDE_END_INCLUDE_START`
-- `Period::EXCLUDE_ALL`
-- `Period::EXCLUDE_NONE`
-- `Period::getBoundaryType`
-- `Period::withBoundaryType`
-- `Period::isStartDateIncluded`
-- `Period::isStartDateExcluded`
-- `Period::isEndDateIncluded`
-- `Period::isEndDateExcluded`
-- `Period::meets`
-- `Period::metBy`
-- `Period::isDuring`
-- `Period::starts`
-- `Period::finishes`
-- `Period::after` supports the `$boundaryType` argument;
-- `Period::before` supports the `$boundaryType` argument;
-- `Period::around` supports the `$boundaryType` argument;
-- `Period::fromDatePeriod` supports the `$boundaryType` argument;
-- `Period::__construct` supports the `$boundaryType` argument;
+- Added support for the boundary types on the package
+    - `Period::EXCLUDE_START_INCLUDE_END`
+    - `Period::INCLUDE_START_EXCLUDE_END`
+    - `Period::EXCLUDE_ALL`
+    - `Period::INCLUDE_ALL`
+    - `Period::getBoundaryType`
+    - `Period::isStartDateExcluded`
+    - `Period::isStartDateIncluded`
+    - `Period::isEndDateExcluded`
+    - `Period::isEndDateIncluded`
+    - `Period::withBoundaryType`
+    - `Period::__construct` adds the `$boundaryType` argument;
+    - `Period::after` adds the `$boundaryType` argument;
+    - `Period::before` adds the `$boundaryType` argument;
+    - `Period::around` adds the `$boundaryType` argument;
+    - `Period::fromDatePeriod` adds the `$boundaryType` argument;
+- Added missing [Allen's Algebra intervals](https://www.ics.uci.edu/~alspaugh/cls/shr/allen.html)
+    - `Period::meets`
+    - `Period::metBy`
+    - `Period::isDuring`
+    - `Period::starts`
+    - `Period::finishes`
 - `Sequence::getUnions`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ All Notable changes to `Period` will be documented in this file
     - `Period::around` adds the `$boundaryType` argument;
     - `Period::fromDatePeriod` adds the `$boundaryType` argument;
 - Added missing [Allen's Algebra intervals](https://www.ics.uci.edu/~alspaugh/cls/shr/allen.html)
-    - `Period::borderOnStart`
-    - `Period::borderOnEnd`
+    - `Period::bordersOnStart`
+    - `Period::bordersOnEnd`
     - `Period::isDuring`
     - `Period::starts`
     - `Period::ends`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All Notable changes to `Period` will be documented in this file
 - `Sequence::intersections`
 - `Sequence::gaps`
 - `Sequence::boundaries`
+- `Sequence::reduce`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,30 @@ All Notable changes to `Period` will be documented in this file
 
 ### Added
 
-- None
+- Added support for the boundary type on all relations methods
+- `Period::EXCLUDE_START_INCLUDE_END`
+- `Period::EXCLUDE_END_INCLUDE_START`
+- `Period::EXCLUDE_ALL`
+- `Period::EXCLUDE_NONE`
+- `Period::getBoundaryType`
+- `Period::withBoundaryType`
+- `Period::isStartDateIncluded`
+- `Period::isStartDateExcluded`
+- `Period::isEndDateIncluded`
+- `Period::isEndDateExcluded`
+- `Period::meets`
+- `Period::metBy`
+- `Period::isDuring`
+- `Period::after` supports the `$boundaryType` argument;
+- `Period::before` supports the `$boundaryType` argument;
+- `Period::around` supports the `$boundaryType` argument;
+- `Period::fromDatePeriod` supports the `$boundaryType` argument;
+- `Period::__construct` supports the `$boundaryType` argument;
+- `Sequence::getUnions`
 
 ### Fixed
 
-- None
+- `Datepoint::createFromFormat` see issue [#72](https://github.com/thephpleague/period/issues/72)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ All Notable changes to `Period` will be documented in this file
     - `Period::EXCLUDE_ALL`
     - `Period::INCLUDE_ALL`
     - `Period::getBoundaryType`
-    - `Period::isStartDateExcluded`
-    - `Period::isStartDateIncluded`
-    - `Period::isEndDateExcluded`
-    - `Period::isEndDateIncluded`
+    - `Period::isStartExcluded`
+    - `Period::isStartIncluded`
+    - `Period::isEndExcluded`
+    - `Period::isEndIncluded`
     - `Period::withBoundaryType`
     - `Period::__construct` adds the `$boundaryType` argument;
     - `Period::after` adds the `$boundaryType` argument;

--- a/composer.json
+++ b/composer.json
@@ -50,9 +50,9 @@
         "phpunit": "phpunit --coverage-text",
         "infection": "infection -j$(nproc) --coverage=build --ignore-msi-with-no-mutations",
         "test": [
+            "@phpcs",
             "@phpstan-src",
             "@phpstan-tests",
-            "@phpcs",
             "@phpunit",
             "@infection"
         ]

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/thephpleague/period/issues"
     },
     "require": {
-        "php" : ">=7.1.3"
+        "php" : "^7.1.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/docs/4.0/comparing.md
+++ b/docs/4.0/comparing.md
@@ -67,12 +67,12 @@ $period->isAfter('1982-06-02'); //returns true
 $period->isAfter($period->getStartDate()); //returns false
 ~~~
 
-### Period::starts
+### Period::startsBy
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::starts(Period $interval): bool
+public Period::startsBy(Period $interval): bool
 ~~~
 
 Tells whether both `Period` objects starts at the same datepoint.
@@ -82,16 +82,16 @@ Tells whether both `Period` objects starts at the same datepoint.
 ~~~php
 $period = Period::fromMonth(2014, 3);
 $alt = Period::after('2014-03-01', '2 DAYS');
-$period->starts($alt); //return true
+$period->startsBy($alt); //return true
 //in this case $period->getStartDate() == $alt->getStartDate();
 ~~~
 
-### Period::ends
+### Period::endsBy
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::ends(Period $interval): bool
+public Period::endsBy(Period $interval): bool
 ~~~
 
 Tells whether both `Period` objects ends at the same datepoint.
@@ -101,7 +101,7 @@ Tells whether both `Period` objects ends at the same datepoint.
 ~~~php
 $period = Period::fromMonth(2014, 3);
 $alt = Period::before('2014-04-01', '2 DAYS');
-$period->ends($alt); //return true
+$period->endsBy($alt); //return true
 //in this case $period->getEndDate() == $alt->getEndDate();
 ~~~
 

--- a/docs/4.0/comparing.md
+++ b/docs/4.0/comparing.md
@@ -86,12 +86,12 @@ $period->starts($alt); //return true
 //in this case $period->getStartDate() == $alt->getStartDate();
 ~~~
 
-### Period::finishes
+### Period::ends
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::finishes(Period $interval): bool
+public Period::ends(Period $interval): bool
 ~~~
 
 Tells whether both `Period` objects ends at the same datepoint.
@@ -101,7 +101,7 @@ Tells whether both `Period` objects ends at the same datepoint.
 ~~~php
 $period = Period::fromMonth(2014, 3);
 $alt = Period::before('2014-04-01', '2 DAYS');
-$period->finishes($alt); //return true
+$period->ends($alt); //return true
 //in this case $period->getEndDate() == $alt->getEndDate();
 ~~~
 

--- a/docs/4.0/comparing.md
+++ b/docs/4.0/comparing.md
@@ -67,6 +67,44 @@ $period->isAfter('1982-06-02'); //returns true
 $period->isAfter($period->getStartDate()); //returns false
 ~~~
 
+### Period::starts
+
+<p class="message-info">Since <code>version 4.4</code></p>
+
+~~~php
+public Period::starts(Period $interval): bool
+~~~
+
+Tells whether both `Period` objects starts at the same datepoint.
+
+#### Examples
+
+~~~php
+$period = Period::fromMonth(2014, 3);
+$alt = Period::after('2014-03-01', '2 DAYS');
+$period->starts($alt); //return true
+//in this case $period->getStartDate() == $alt->getStartDate();
+~~~
+
+### Period::finishes
+
+<p class="message-info">Since <code>version 4.4</code></p>
+
+~~~php
+public Period::finishes(Period $interval): bool
+~~~
+
+Tells whether both `Period` objects ends at the same datepoint.
+
+#### Examples
+
+~~~php
+$period = Period::fromMonth(2014, 3);
+$alt = Period::before('2014-04-01', '2 DAYS');
+$period->finishes($alt); //return true
+//in this case $period->getEndDate() == $alt->getEndDate();
+~~~
+
 ### Period::abuts
 
 ~~~php
@@ -83,7 +121,7 @@ A `Period` abuts if it starts immediately after, or ends immediately before the 
 $period = Period::fromMonth(2014, 3);
 $alt = Period::fromMonth(2014, 4);
 $period->abuts($alt); //return true
-//in this case $period->getEndDate() === $alt->getStartDate();
+//in this case $period->getEndDate() == $alt->getStartDate();
 ~~~
 
 ### Period::meets

--- a/docs/4.0/comparing.md
+++ b/docs/4.0/comparing.md
@@ -124,12 +124,12 @@ $period->abuts($alt); //return true
 //in this case $period->getEndDate() == $alt->getStartDate();
 ~~~
 
-### Period::meets
+### Period::borderOnStart
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::meets(Period $interval): bool
+public Period::borderOnStart(Period $interval): bool
 ~~~
 
 A `Period` meets another one if its ending datepoint is immediately before the submitted `Period` starting datepoint without overlapping.
@@ -142,15 +142,15 @@ $period = Period::fromMonth(1983, 4);
 
 //comparing two Period objects
 $alt = Period::fromMonth(1983, 3);
-$alt->meets($period); //return true;
+$alt->borderOnStart($period); //return true;
 ~~~
 
-### Period::metBy
+### Period::borderOnEnd
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::metBy(Period $interval): bool
+public Period::borderOnEnd(Period $interval): bool
 ~~~
 
 A `Period` is met by another one if its starting datepoint is immediately after the submitted `Period` end datepoint without overlapping.
@@ -163,7 +163,7 @@ $period = Period::fromMonth(1983, 4);
 
 //comparing two Period objects
 $alt = Period::fromMonth(1983, 3);
-$period->metBy($alt); //return true;
+$period->borderOnEnd($alt); //return true;
 ~~~
 
 ### Period::overlaps

--- a/docs/4.0/comparing.md
+++ b/docs/4.0/comparing.md
@@ -86,6 +86,48 @@ $period->abuts($alt); //return true
 //in this case $period->getEndDate() === $alt->getStartDate();
 ~~~
 
+### Period::meets
+
+<p class="message-info">Since <code>version 4.4</code></p>
+
+~~~php
+public Period::meets(Period $interval): bool
+~~~
+
+A `Period` meets another one if its ending datepoint is immediately before the submitted `Period` starting datepoint without overlapping.
+
+#### Examples
+
+~~~php
+//comparing a datetime
+$period = Period::fromMonth(1983, 4);
+
+//comparing two Period objects
+$alt = Period::fromMonth(1983, 3);
+$alt->meets($period); //return true;
+~~~
+
+### Period::metBy
+
+<p class="message-info">Since <code>version 4.4</code></p>
+
+~~~php
+public Period::metBy(Period $interval): bool
+~~~
+
+A `Period` is met by another one if its starting datepoint is immediately after the submitted `Period` end datepoint without overlapping.
+
+#### Examples
+
+~~~php
+//comparing a datetime
+$period = Period::fromMonth(1983, 4);
+
+//comparing two Period objects
+$alt = Period::fromMonth(1983, 3);
+$period->metBy($alt); //return true;
+~~~
+
 ### Period::overlaps
 
 ~~~php
@@ -151,6 +193,28 @@ $period->contains($period->getEndDate());   //returns false;
 $alt = Period::after('1983-04-12', '12 DAYS');
 $period->contains($alt); //return true;
 $alt->contains($period); //return false;
+~~~
+
+### Period::isDuring
+
+<p class="message-info">Since <code>version 4.4</code></p>
+
+~~~php
+public Period::isDuring(Period $interval): bool
+~~~
+
+A `Period` is contained into another if its datetime continuum is completely contained within the submitted `Period` datetime continuum.
+
+#### Examples
+
+~~~php
+//comparing a datetime
+$period = Period::fromMonth(1983, 4);
+
+//comparing two Period objects
+$alt = Period::after('1983-04-12', '12 DAYS');
+$period->contains($alt); //return true;
+$alt->isDuring($period); //return true;
 ~~~
 
 ### Period::diff

--- a/docs/4.0/comparing.md
+++ b/docs/4.0/comparing.md
@@ -124,12 +124,12 @@ $period->abuts($alt); //return true
 //in this case $period->getEndDate() == $alt->getStartDate();
 ~~~
 
-### Period::borderOnStart
+### Period::bordersOnStart
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::borderOnStart(Period $interval): bool
+public Period::bordersOnStart(Period $interval): bool
 ~~~
 
 A `Period` meets another one if its ending datepoint is immediately before the submitted `Period` starting datepoint without overlapping.
@@ -142,15 +142,15 @@ $period = Period::fromMonth(1983, 4);
 
 //comparing two Period objects
 $alt = Period::fromMonth(1983, 3);
-$alt->borderOnStart($period); //return true;
+$alt->bordersOnStart($period); //return true;
 ~~~
 
-### Period::borderOnEnd
+### Period::bordersOnEnd
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::borderOnEnd(Period $interval): bool
+public Period::bordersOnEnd(Period $interval): bool
 ~~~
 
 A `Period` is met by another one if its starting datepoint is immediately after the submitted `Period` end datepoint without overlapping.
@@ -163,7 +163,7 @@ $period = Period::fromMonth(1983, 4);
 
 //comparing two Period objects
 $alt = Period::fromMonth(1983, 3);
-$period->borderOnEnd($alt); //return true;
+$period->bordersOnEnd($alt); //return true;
 ~~~
 
 ### Period::overlaps

--- a/docs/4.0/datepoint.md
+++ b/docs/4.0/datepoint.md
@@ -67,7 +67,7 @@ public Datepoint::getIsoYear(): Period
 
 For each a these methods a `Period` object is returned with:
 
-- the `Period::EXCLUDE_END_INCLUDE_START` boundary type;
+- the `Period::INCLUDE_START_EXCLUDE_END` boundary type;
 - the starting datepoint represents the beginning of the current datepoint calendar interval;
 - the duration associated with the given calendar interval;
 

--- a/docs/4.0/datepoint.md
+++ b/docs/4.0/datepoint.md
@@ -67,6 +67,7 @@ public Datepoint::getIsoYear(): Period
 
 For each a these methods a `Period` object is returned with:
 
+- the `Period::EXCLUDE_END_INCLUDE_START` boundary type;
 - the starting datepoint represents the beginning of the current datepoint calendar interval;
 - the duration associated with the given calendar interval;
 

--- a/docs/4.0/definitions.md
+++ b/docs/4.0/definitions.md
@@ -7,15 +7,25 @@ title: Concepts and arguments
 
 ## Concepts
 
-- **interval** - `Period` is a PHP implementation of a left closed right open datetime interval which consists of two datepoints and the duration between them. This means that:
+<p class="message-info">Since <code>version 4.4</code> all basic boundary types are supported by the library.</p>
 
-    - The starting datepoint is included in the interval.
-    - The ending datepoint is excluded from the interval.
-    - The starting datepoint is always less than or equal to the ending datepoint.
+- **interval** - `Period` is a PHP implementation of a datetime interval which consists of:
+
+- two datepoints;
+- the duration between them;
+- a boundary type. By default, and to avoid any BC break the package returns a left close right open interval;
+
+The starting datepoint is always less than or equal to the ending datepoint.
 
 - **datepoint** - A position in time expressed as a `DateTimeImmutable` object.
 
 - **duration** - The continuous portion of time between two datepoints expressed as a `DateInterval` object. The duration cannot be negative.
+
+- **boundary type** - The package supports the following boundary type:
+	- `[)` : left close, right open using `Period::EXCLUDE_END_INCLUDE_START`;
+	- `(]` : left open, right close using `Period::EXCLUDE_START_INCLUDE_END`;
+	- `[]` : left close, right close using `Period::EXCLUDE_NONE`;
+	- `()` : left open, right open using `Period::EXCLUDE_ALL`;
 
 ## Arguments
 

--- a/docs/4.0/definitions.md
+++ b/docs/4.0/definitions.md
@@ -10,22 +10,23 @@ title: Concepts and arguments
 <p class="message-info">Since <code>version 4.4</code> all basic boundary types are supported by the library.</p>
 
 - **interval** - `Period` is a PHP implementation of a datetime interval which consists of:
+	- two datepoints;
+	- the duration between them;
+	- a boundary type. 
 
-- two datepoints;
-- the duration between them;
-- a boundary type. 
 
-The starting datepoint is always less than or equal to the ending datepoint.
-
-- **datepoint** - A position in time expressed as a `DateTimeImmutable` object.
+- **datepoint** - A position in time expressed as a `DateTimeImmutable` object. The starting datepoint is always less than or equal to the ending datepoint.
 
 - **duration** - The continuous portion of time between two datepoints expressed as a `DateInterval` object. The duration cannot be negative.
 
-- **boundary type** - The package supports inclusive and exclusive datepoint.
-	- An inclusive starting datepoint is represented by `[`;
-	- An exclusive starting datepoint is represented by `(`;
-	- An inclusive ending datepoint is represented by `]`;
-	- An exclusive ending datepoint is represented by `)`;
+- **boundary type** - An included datepoint means that the boundary datepoint itself is included in the interval as well, while an excluded datepoint means that the boundary datepoint is not included in the interval.  
+The package supports included and excluded datepoint, thus, the following boundary types are supported:
+	- included starting datepoint and excluded ending datepoint: `[start, end)`;
+	- included starting datepoint and included ending datepoint : `[start, end]`;
+	- excluded starting datepoint and included ending datepoint : `(start, end]`;
+	- excluded starting datepoint and excluded ending datepoint : `(start, end)`;
+
+<p class="message-warning">infinite or unbounded intervals are not supported.</p>
 
 ## Arguments
 

--- a/docs/4.0/definitions.md
+++ b/docs/4.0/definitions.md
@@ -13,7 +13,7 @@ title: Concepts and arguments
 
 - two datepoints;
 - the duration between them;
-- a boundary type. By default, and to avoid any BC break the package returns a left close right open interval;
+- a boundary type. 
 
 The starting datepoint is always less than or equal to the ending datepoint.
 
@@ -21,11 +21,11 @@ The starting datepoint is always less than or equal to the ending datepoint.
 
 - **duration** - The continuous portion of time between two datepoints expressed as a `DateInterval` object. The duration cannot be negative.
 
-- **boundary type** - The package supports the following boundary type:
-	- `[)` : left close, right open using `Period::EXCLUDE_END_INCLUDE_START`;
-	- `(]` : left open, right close using `Period::EXCLUDE_START_INCLUDE_END`;
-	- `[]` : left close, right close using `Period::EXCLUDE_NONE`;
-	- `()` : left open, right open using `Period::EXCLUDE_ALL`;
+- **boundary type** - The package supports inclusive and exclusive datepoint.
+	- An inclusive starting datepoint is represented by `[`;
+	- An exclusive starting datepoint is represented by `(`;
+	- An inclusive ending datepoint is represented by `]`;
+	- An exclusive ending datepoint is represented by `)`;
 
 ## Arguments
 

--- a/docs/4.0/instantiation.md
+++ b/docs/4.0/instantiation.md
@@ -23,24 +23,37 @@ public Period::__construct(
 
 #### Parameters
 
-Both `$startDate` and `$endDate` parameters are datepoints. `$endDate` **must be** greater or equal to `$startDate` or the instantiation will throw a `Period\Exception`.
-
 - The `$startDate` represents **the starting datepoint**.
 - The `$endDate` represents **the ending datepoint**.
-- The `$boundaryType` represents **the interval boundary type** like [explain in the definition section](/4.0/definitions/#concepts). It can take one of the following constants:
-    - `Period::INCLUDE_ALL` : the starting and ending datepoints **are included** in the interval;
-    - `Period::EXCLUDE_ALL` : the starting and ending datepoints **are excluded** from the interval;
-    - `Period::EXCLUDE_START_INCLUDE_END` : the starting datepoint **is excluded from** and the ending datepoint **is included in** the interval;
-    - `Period::INCLUDE_START_EXCLUDE_END` : the starting datepoint **is included in** and the ending datepoint **is excluded from** the interval; 
+- The `$boundaryType` represents **the interval boundary type**. 
 
-<p class="message-info">By default and to avoid BC break the <code>$boundaryType</code> is <code>Period::INCLUDE_START_EXCLUDE_END</code>.</p>
+Both `$startDate` and `$endDate` parameters are datepoints. `$endDate` **must be** greater or equal to `$startDate` or the instantiation will throw a `Period\Exception`.
+
+The `$boundaryType` can only take one of the following values:
+
+- `[]` : the starting and ending datepoints **are included** in the interval;
+- `()` : the starting and ending datepoints **are excluded** from the interval;
+- `(]` : the starting datepoint **is excluded from** and the ending datepoint **is included in** the interval;
+- `[)` : the starting datepoint **is included in** and the ending datepoint **is excluded from** the interval;
+
+To ease remembering those values the following constants are introduced:
+
+- `Period::INCLUDE_ALL` whose value is `[]`;
+- `Period::EXCLUDE_ALL` whose value is `()`;
+- `Period::EXCLUDE_START_INCLUDE_END` whose value is `(]`;
+- `Period::INCLUDE_START_EXCLUDE_END` whose value is `[)`; 
+
+<p class="message-warning">By default and to avoid BC break the <code>$boundaryType</code> is <code>Period::INCLUDE_START_EXCLUDE_END</code> when not explicitly provided.</p>
 
 #### Example
 
 ~~~php
 use League\Period\Period;
 
-$period = new Period('2012-04-01 08:30:25', new DateTime('2013-09-04 12:35:21'), Period::EXCLUDE_ALL);
+$period1 = new Period('2012-04-01 08:30:25', '2013-09-04 12:35:21', '()');
+$period2 = new Period('2012-04-01 08:30:25', new DateTime('2013-09-04 12:35:21'), Period::EXCLUDE_ALL);
+
+$period1->equals($period2); // true
 ~~~
 
 ## Named constructors

--- a/docs/4.0/instantiation.md
+++ b/docs/4.0/instantiation.md
@@ -12,25 +12,35 @@ To instantiate a `Period` object you can rely on its constructor or on several h
 ## The constructor
 
 ~~~php
-public Period::__construct(mixed $startDate, mixed $endDate)
+public Period::__construct(mixed $startDate, mixed $endDate, string $boundaryType = self::EXCLUDE_END_INCLUDE_START)
 ~~~
+
+<p class="message-info">Since <code>version 4.4</code> the <code>$boundaryType</code> argument is added.</p>
 
 #### Parameters
 
 Both `$startDate` and `$endDate` parameters are datepoints.
 
-- The `$startDate` represents **the starting included datepoint**.
-- The `$endDate` represents **the ending excluded datepoint**.
+- The `$startDate` represents **the starting datepoint**.
+- The `$endDate` represents **the ending datepoint**.
+- The `$boundaryType` represents **the interval boundary type**. It can take one of the following constants:
+	- `Period::EXCLUDE_NONE` : the starting and ending datepoint **are included** in the interval;
+	- `Period::EXCLUDE_ALL` :  the starting and ending datepoint **are excluded** in the interval;
+	- `Period::EXCLUDE_START_INCLUDE_END` : the starting datepoint **is excluded** and the ending datepoint **is included** from the interval;
+	- `Period::EXCLUDE_END_INCLUDE_START` : the starting datepoint **is included** and the ending datepoint **is excluded** from the interval; 
+
 
 `$endDate` **must be** greater or equal to `$startDate` or the instantiation will throw a `Period\Exception`.
+<p class="message-info">By default and to avoid BC break the <code>$boundaryType</code> is <code>Period::EXCLUDE_END_INCLUDE_START</code>.</p>
 
 #### Example
 
 ~~~php
 use League\Period\Period;
 
-$period = new Period('2012-04-01 08:30:25', new DateTime('2013-09-04 12:35:21'));
+$period = new Period('2012-04-01 08:30:25', new DateTime('2013-09-04 12:35:21'), Period::EXCLUDE_ALL);
 ~~~
+
 
 ## Named constructors
 
@@ -40,13 +50,19 @@ Apart from its constructor, to ease the class instantiation you can rely on many
 
 ### Named constructors accepting a DatePeriod object
 
+<p class="message-notice">Since <code>version 4.4</code> the <code>$boundaryType</code> argument is added.</p>
+
 ~~~php
-function Period::fromDatePeriod(DatePeriod $datePeriod): Period
+function Period::fromDatePeriod(
+	DatePeriod $datePeriod,
+	string $boundaryType = self::EXCLUDE_END_INCLUDE_START
+): self
 ~~~
 
 #### Parameter
 
 - `$datePeriod` is a `DatePeriod` object.
+- `$boundaryType`, the interval boundary type.
 
 #### Example
 
@@ -90,6 +106,8 @@ public static Period::fromIsoYear(int $year): Period
 
 <p class="message-info">The datepoints will be created following PHP <code>DateTimeImmutable::setDate</code>, <code>DateTimeImmutable::setISODate</code> and <code>DateTimeImmutable::setTime</code> rules<br> which means that overflow is possible and acceptable.</p>
 
+<p class="message-info">The following named constructors always returns a <code>Period</code> instance with the following boundary type <code>Period::EXCLUDE_END_INCLUDE_START</code>.</p>
+
 #### Examples
 
 ~~~php
@@ -102,9 +120,9 @@ $day->getStartDate()->format('Y-m-d H:i:s'); //return 2012-01-01 00:00:00
 ### Named constructors accepting a datepoint and/or a duration
 
 ~~~php
-public static Period::after(mixed $datepoint, mixed $duration): Period
-public static Period::before(mixed $datepoint, mixed $duration): Period
-public static Period::around(mixed $datepoint, mixed $duration): Period
+public static Period::after(mixed $datepoint, mixed $duration, string $boundaryType = self::EXCLUDE_END_INCLUDE_START): Period
+public static Period::before(mixed $datepoint, mixed $duration, string $boundaryType = self::EXCLUDE_END_INCLUDE_START): Period
+public static Period::around(mixed $datepoint, mixed $duration, string $boundaryType = self::EXCLUDE_END_INCLUDE_START): Period
 ~~~
 
 - `Period::after` returns a `Period` object which starts at `$datepoint`
@@ -113,8 +131,9 @@ public static Period::around(mixed $datepoint, mixed $duration): Period
 
 #### Parameters
 
-- `$datepoint`: represents a datepoint
+- `$datepoint` represents a datepoint.
 - `$duration` represents a duration.
+- `$boundaryType` the interval boundary type.
 
 #### Examples
 

--- a/docs/4.0/modifying.md
+++ b/docs/4.0/modifying.md
@@ -179,6 +179,27 @@ $new_interval->getStartDate(); //returns DateTimeImmutable('2014-03-02');
 $new_interval->getEndDate();   //returns DateTimeImmutable('2014-03-31');
 ~~~
 
+## Using the boundary information
+
+### Period::withBoundaryType
+
+<p class="message-info">Since <code>version 4.4</code></p>
+
+~~~php
+public Period::withBoundaryType(string $boundaryType): Period
+~~~
+
+Returns a new `Period` object with a different boundary type.
+
+#### Example
+
+~~~php
+$interval = Period::fromMonth(2014, 3);
+$new_interval = $interval->withBoundaryType(Period::INCLUDE_ALL);
+$interval->format('Y-m-d'); // '[2014-03-01, 2014-04-01)'
+$new_interval->format('Y-m-d'); // '[2014-03-01, 2014-04-01]'
+~~~
+
 ## Using another Period object
 
 ### Period::merge

--- a/docs/4.0/properties.md
+++ b/docs/4.0/properties.md
@@ -15,10 +15,10 @@ public Period::getEndDate(void): DateTimeImmutable
 public Period::getDateInterval(void): DateInterval
 public Period::getTimestampInterval(void): float
 public Period::getBoundaryType(void): string
-public Period::isStartDateIncluded(): bool
-public Period::isStartDateExcluded(): bool
-public Period::isEndDateIncluded(): bool
-public Period::isEndDateExcluded(): bool
+public Period::isStartIncluded(): bool
+public Period::isStartExcluded(): bool
+public Period::isEndIncluded(): bool
+public Period::isEndExcluded(): bool
 ~~~
 
 ~~~php
@@ -28,10 +28,10 @@ $period->getEndDate(); //returns DateTimeImmutable('2013-09-04 12:35:21');
 $duration = $period->getDateInterval(); //returns a DateInterval object
 $altduration = $period->getTimestampInterval(); //returns the duration in seconds
 $period->getBoundaryType(); //returns Period::INCLUDE_START_EXCLUDE_END 
-$period->isStartDateExcluded(); //returns false
-$period->isStartDateIncluded(); //returns true
-$period->isEndDateExcluded(); //returns true
-$period->isEndDateIncluded(); //returns false
+$period->isStartExcluded(); //returns false
+$period->isStartIncluded(); //returns true
+$period->isEndExcluded(); //returns true
+$period->isEndIncluded(); //returns false
 ~~~
 
 ## Iteration over a Period

--- a/docs/4.0/properties.md
+++ b/docs/4.0/properties.md
@@ -14,6 +14,11 @@ public Period::getStartDate(void): DateTimeImmutable
 public Period::getEndDate(void): DateTimeImmutable
 public Period::getDateInterval(void): DateInterval
 public Period::getTimestampInterval(void): float
+public Period::getBoundaryType(void): string
+public Period::isStartDateIncluded(): bool
+public Period::isStartDateExcluded(): bool
+public Period::isEndDateIncluded(): bool
+public Period::isEndDateExcluded(): bool
 ~~~
 
 ~~~php
@@ -22,6 +27,11 @@ $period->getStartDate(); //returns DateTimeImmutable('2012-04-01 08:30:25');
 $period->getEndDate(); //returns DateTimeImmutable('2013-09-04 12:35:21');
 $duration = $period->getDateInterval(); //returns a DateInterval object
 $altduration = $period->getTimestampInterval(); //returns the duration in seconds
+$period->getBoundaryType(); //returns Period::EXCLUDE_END_INCLUDE_START 
+$period->isStartDateExcluded(); //returns false
+$period->isStartDateIncluded(); //returns true
+$period->isEndDateExcluded(); //returns true
+$period->isEndDateIncluded(); //returns false
 ~~~
 
 ## Iteration over a Period

--- a/docs/4.0/properties.md
+++ b/docs/4.0/properties.md
@@ -27,7 +27,7 @@ $period->getStartDate(); //returns DateTimeImmutable('2012-04-01 08:30:25');
 $period->getEndDate(); //returns DateTimeImmutable('2013-09-04 12:35:21');
 $duration = $period->getDateInterval(); //returns a DateInterval object
 $altduration = $period->getTimestampInterval(); //returns the duration in seconds
-$period->getBoundaryType(); //returns Period::EXCLUDE_END_INCLUDE_START 
+$period->getBoundaryType(); //returns Period::INCLUDE_START_EXCLUDE_END 
 $period->isStartDateExcluded(); //returns false
 $period->isStartDateIncluded(); //returns true
 $period->isEndDateExcluded(); //returns true

--- a/docs/4.0/sequence/container.md
+++ b/docs/4.0/sequence/container.md
@@ -63,7 +63,7 @@ $intersections = $sequence->getIntersections(); // a new Sequence object
 $intersections->isEmpty(); // true
 ~~~
 
-### Sequence::getUnions
+### Sequence::unions
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
@@ -75,7 +75,7 @@ $sequence = new Sequence(
     new Period('2017-01-01', '2017-01-31'),
     new Period('2018-01-15', '2018-02-15')
 );
-$unions = $sequence->getUnions(); // a new Sequence object
+$unions = $sequence->unions(); // a new Sequence object
 count($unions); // returns 2
 ~~~
 

--- a/docs/4.0/sequence/container.md
+++ b/docs/4.0/sequence/container.md
@@ -18,7 +18,10 @@ $sequence = new Sequence(new Period('2018-01-01', '2018-01-31'));
 $sequence->isEmpty(); // false
 ~~~
 
-### Sequence::getBoundaries
+### Sequence::boundaries
+
+<p class="message-info">Since <code>version 4.4</code>.</p>
+<p class="message-warning"><code>Sequence::getBoundaries</code> is deprecated and will be remove in the next major release.</p>
 
 Returns the sequence boundaries as a `Period` instance. If the sequence is empty `null` is returned.
 
@@ -29,11 +32,14 @@ $sequence = new Sequence(
     new Period('2018-03-01', '2018-03-31'),
     new Period('2018-01-20', '2018-03-10')
 );
-$sequence->getBoundaries()->format('Y-m-d'); // [2018-01-01, 2018-03-10)
-(new Sequence())->getBoundaries(); // null
+$sequence->boundaries()->format('Y-m-d'); // [2018-01-01, 2018-03-10)
+(new Sequence())->boundaries(); // null
 ~~~
 
-### Sequence::getGaps
+### Sequence::gaps
+
+<p class="message-info">Since <code>version 4.4</code>.</p>
+<p class="message-warning"><code>Sequence::getGaps</code> is deprecated and will be remove in the next major release.</p>
 
 Returns the gaps inside the instance. The method returns a new `Sequence` object containing the founded
 gaps expressed as `Period` objects.
@@ -44,11 +50,14 @@ $sequence = new Sequence(
     new Period('2017-01-01', '2017-01-31'),
     new Period('2020-01-01', '2020-01-31')
 );
-$gaps = $sequence->getGaps(); // a new Sequence object
+$gaps = $sequence->gaps(); // a new Sequence object
 count($gaps); // 2
 ~~~
 
-### Sequence::getIntersections
+### Sequence::intersections
+
+<p class="message-info">Since <code>version 4.4</code>.</p>
+<p class="message-warning"><code>Sequence::getIntersections</code> is deprecated and will be remove in the next major release.</p>
 
 Returns the intersections inside the instance. The method returns a new `Sequence` object containing the founded
 intersections expressed as `Period` objects.
@@ -59,7 +68,7 @@ $sequence = new Sequence(
     new Period('2017-01-01', '2017-01-31'),
     new Period('2020-01-01', '2020-01-31')
 );
-$intersections = $sequence->getIntersections(); // a new Sequence object
+$intersections = $sequence->intersections(); // a new Sequence object
 $intersections->isEmpty(); // true
 ~~~
 
@@ -261,4 +270,40 @@ $newSequence = $sequence->map($func);
 count($sequence); // 3
 count($newSequence); //3
 $newSequence->get(2)->format('Y-m-d'); // [2020-01-01, 2020-02-01)
+~~~
+
+### Sequence::reduce
+
+<p class="message-info">new since <code>version 4.4</code></p>
+
+Iteratively reduces the sequence to a single value using a callback. The returned value is the carry value of the final iteration, or the initial value if the sequence was empty.
+
+The reducer is a `callable` whose signature is as follows:
+
+~~~php
+function($carry, Period $interval [, int $offset]): mixed
+~~~
+
+It takes up to three (3) parameters:
+
+- `$carry` : the optional initial carry value or null
+- `$interval` : the Sequence value which is a `Period` object
+- `$offset` : the Sequence value corresponding offset
+
+~~~php
+$sequence = new Sequence(
+    new Period('2018-01-01', '2018-01-31'),
+    new Period('2019-01-01', '2019-01-31'),
+    new Period('2020-01-01', '2020-01-31')
+);
+
+$func = static function ($carry, Period $interval): Period {
+    if (null === $carry) {
+        return $interval;
+    }
+    return $carry->merge($interval);
+};
+
+$mergePeriod = $sequence->reduce($func);
+$mergePeriod->format('Y-m-d'); // [2018-01-01, 2020-01-31)
 ~~~

--- a/docs/4.0/sequence/container.md
+++ b/docs/4.0/sequence/container.md
@@ -63,6 +63,22 @@ $intersections = $sequence->getIntersections(); // a new Sequence object
 $intersections->isEmpty(); // true
 ~~~
 
+### Sequence::getUnions
+
+<p class="message-info">Since <code>version 4.4</code></p>
+
+Returns the unions inside the instance. The method returns a new `Sequence` object containing the calculated unions expressed as `Period` objects.
+
+~~~php
+$sequence = new Sequence(
+    new Period('2018-01-01', '2018-01-31'),
+    new Period('2017-01-01', '2017-01-31'),
+    new Period('2018-01-15', '2018-02-15')
+);
+$unions = $sequence->getUnions(); // a new Sequence object
+count($unions); // returns 2
+~~~
+
 ### Sequence::indexOf
 
 Returns the offset of the given `Period` object. The comparison of two intervals is done using `Period::equals` method. If no offset is found `false` is returned.

--- a/src/Datepoint.php
+++ b/src/Datepoint.php
@@ -63,7 +63,7 @@ final class Datepoint extends DateTimeImmutable
      * @param string       $datetime
      * @param DateTimeZone $timezone
      *
-     * @return self|bool
+     * @return self|false
      */
     public static function createFromFormat($format, $datetime, $timezone = null)
     {
@@ -144,7 +144,7 @@ final class Datepoint extends DateTimeImmutable
     /**
      * Returns a Period instance.
      *
-     *  - the starting datepoint represents the beginning of the current datepoint iso week day
+     *  - the starting datepoint represents the beginning of the current datepoint iso week
      *  - the duration is equal to 7 days
      */
     public function getIsoWeek(): Period

--- a/src/Datepoint.php
+++ b/src/Datepoint.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *
@@ -59,12 +59,13 @@ final class Datepoint extends DateTimeImmutable
     /**
      * @inheritdoc
      *
-     * @param string $format
-     * @param string $datetime
+     * @param string       $format
+     * @param string       $datetime
+     * @param DateTimeZone $timezone
      *
      * @return self|bool
      */
-    public static function createFromFormat($format, $datetime, DateTimeZone $timezone = null)
+    public static function createFromFormat($format, $datetime, $timezone = null)
     {
         $datepoint = parent::createFromFormat($format, $datetime, $timezone);
         if (false !== $datepoint) {

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/InvalidIndex.php
+++ b/src/InvalidIndex.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Period.php
+++ b/src/Period.php
@@ -132,9 +132,8 @@ final class Period implements JsonSerializable
     public static function before($endDate, $duration, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
         $endDate = self::getDatepoint($endDate);
-        $duration = self::getDuration($duration);
 
-        return new self($endDate->sub($duration), $endDate, $boundaryType);
+        return new self($endDate->sub(self::getDuration($duration)), $endDate, $boundaryType);
     }
 
     /**
@@ -279,7 +278,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Returns the instance range type.
+     * Returns the instance boundary type.
      */
     public function getBoundaryType(): string
     {
@@ -348,7 +347,7 @@ final class Period implements JsonSerializable
      **************************************************/
 
     /**
-     * Tells whether the start datepoint is included in the range.
+     * Tells whether the start datepoint is included in the boundary.
      */
     public function isStartDateIncluded(): bool
     {
@@ -356,7 +355,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Tells whether the start datepoint is excluded from the range.
+     * Tells whether the start datepoint is excluded from the boundary.
      */
     public function isStartDateExcluded(): bool
     {
@@ -364,7 +363,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Tells whether the end datepoint is included in the range.
+     * Tells whether the end datepoint is included in the boundary.
      */
     public function isEndDateIncluded(): bool
     {
@@ -372,7 +371,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Tells whether the end datepoint is excluded from the range.
+     * Tells whether the end datepoint is excluded from the boundary.
      */
     public function isEndDateExcluded(): bool
     {
@@ -421,7 +420,6 @@ final class Period implements JsonSerializable
     {
         return -1 === $this->durationCompare($interval);
     }
-
 
     /**************************************************
      * relation methods
@@ -474,8 +472,7 @@ final class Period implements JsonSerializable
      */
     public function metBy(self $interval): bool
     {
-        return $this->startDate == $interval->endDate
-            && '][' !== $interval->boundaryType[1].$this->boundaryType[0];
+        return $interval->meets($this);
     }
 
     /**
@@ -486,7 +483,7 @@ final class Period implements JsonSerializable
      *
      * or
      *
-     *    [------------------------------)
+     *    [--------------------)
      *    [---------)
      */
     public function starts(self $interval): bool
@@ -503,8 +500,8 @@ final class Period implements JsonSerializable
      *
      * or
      *
-     *    [------------------------------)
-     *                         [---------)
+     *    [--------------------)
+     *               [---------)
      */
     public function finishes(self $interval): bool
     {
@@ -559,8 +556,7 @@ final class Period implements JsonSerializable
     public function isAfter($index): bool
     {
         if ($index instanceof self) {
-            return $this->startDate > $index->endDate
-                || ($this->startDate == $index->endDate && $this->boundaryType[1] !== $index->boundaryType[0]);
+            return $index->isBefore($this);
         }
 
         $datepoint = self::getDatepoint($index);

--- a/src/Period.php
+++ b/src/Period.php
@@ -64,7 +64,7 @@ final class Period implements JsonSerializable
     private $endDate;
 
     /**
-     * Range type.
+     * The boundary type.
      *
      * @var string
      */

--- a/src/Period.php
+++ b/src/Period.php
@@ -503,7 +503,7 @@ final class Period implements JsonSerializable
      *    [--------------------)
      *               [---------)
      */
-    public function finishes(self $interval): bool
+    public function ends(self $interval): bool
     {
         return $this->endDate == $interval->endDate
             && $this->boundaryType[1] === $interval->boundaryType[1];

--- a/src/Period.php
+++ b/src/Period.php
@@ -19,6 +19,9 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use JsonSerializable;
+use function array_keys;
+use function implode;
+use function sprintf;
 
 /**
  * A immutable value object class to manipulate Time interval.
@@ -32,10 +35,10 @@ final class Period implements JsonSerializable
     private const ISO8601_FORMAT = 'Y-m-d\TH:i:s.u\Z';
 
     private const BOUNDARY_TYPE = [
-        self::INCLUDE_ALL => 1,
-        self::EXCLUDE_ALL => 1,
         self::INCLUDE_START_EXCLUDE_END => 1,
+        self::INCLUDE_ALL => 1,
         self::EXCLUDE_START_INCLUDE_END => 1,
+        self::EXCLUDE_ALL => 1,
     ];
 
     public const INCLUDE_START_EXCLUDE_END = '[)';
@@ -247,7 +250,11 @@ final class Period implements JsonSerializable
         }
 
         if (!isset(self::BOUNDARY_TYPE[$boundaryType])) {
-            throw new Exception('The boundary `%s` is unknown or not supported');
+            throw new Exception(sprintf(
+                'The boundary type `%s` is invalid. The only valid values are %s',
+                $boundaryType,
+                '`'.implode('`, `', array_keys(self::BOUNDARY_TYPE)).'`'
+            ));
         }
 
         $this->startDate = $startDate;

--- a/src/Period.php
+++ b/src/Period.php
@@ -449,7 +449,7 @@ final class Period implements JsonSerializable
      */
     public function abuts(self $interval): bool
     {
-        return $this->borderOnStart($interval) || $this->borderOnEnd($interval);
+        return $this->bordersOnStart($interval) || $this->bordersOnEnd($interval);
     }
 
     /**
@@ -458,7 +458,7 @@ final class Period implements JsonSerializable
      * [--------------------)
      *                      [--------------------)
      */
-    public function borderOnStart(self $interval): bool
+    public function bordersOnStart(self $interval): bool
     {
         return $this->endDate == $interval->startDate
             && '][' !== $this->boundaryType[1].$interval->boundaryType[0];
@@ -470,9 +470,9 @@ final class Period implements JsonSerializable
      *                      [--------------------)
      * [--------------------)
      */
-    public function borderOnEnd(self $interval): bool
+    public function bordersOnEnd(self $interval): bool
     {
-        return $interval->borderOnStart($this);
+        return $interval->bordersOnStart($this);
     }
 
     /**

--- a/src/Period.php
+++ b/src/Period.php
@@ -349,7 +349,7 @@ final class Period implements JsonSerializable
     /**
      * Tells whether the start datepoint is included in the boundary.
      */
-    public function isStartDateIncluded(): bool
+    public function isStartIncluded(): bool
     {
         return '[' === $this->boundaryType[0];
     }
@@ -357,7 +357,7 @@ final class Period implements JsonSerializable
     /**
      * Tells whether the start datepoint is excluded from the boundary.
      */
-    public function isStartDateExcluded(): bool
+    public function isStartExcluded(): bool
     {
         return '(' === $this->boundaryType[0];
     }
@@ -365,7 +365,7 @@ final class Period implements JsonSerializable
     /**
      * Tells whether the end datepoint is included in the boundary.
      */
-    public function isEndDateIncluded(): bool
+    public function isEndIncluded(): bool
     {
         return ']' === $this->boundaryType[1];
     }
@@ -373,7 +373,7 @@ final class Period implements JsonSerializable
     /**
      * Tells whether the end datepoint is excluded from the boundary.
      */
-    public function isEndDateExcluded(): bool
+    public function isEndExcluded(): bool
     {
         return ')' === $this->boundaryType[1];
     }
@@ -881,8 +881,8 @@ final class Period implements JsonSerializable
             throw new Exception('Both '.self::class.' objects must not overlaps');
         }
 
-        $boundaryType = $this->isEndDateExcluded() ? '[' : '(';
-        $boundaryType .= $interval->isStartDateExcluded() ? ']' : ')';
+        $boundaryType = $this->isEndExcluded() ? '[' : '(';
+        $boundaryType .= $interval->isStartExcluded() ? ']' : ')';
         if ($interval->startDate > $this->startDate) {
             return new self($this->endDate, $interval->startDate, $boundaryType);
         }

--- a/src/Period.php
+++ b/src/Period.php
@@ -476,7 +476,8 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Tells whether two intervals share the same start datepoint.
+     * Tells whether two intervals share the same start datepoint
+     * and the same starting boundary type.
      *
      *    [----------)
      *    [--------------------)
@@ -486,14 +487,15 @@ final class Period implements JsonSerializable
      *    [--------------------)
      *    [---------)
      */
-    public function starts(self $interval): bool
+    public function startsBy(self $interval): bool
     {
         return $this->startDate == $interval->startDate
             && $this->boundaryType[0] === $interval->boundaryType[0];
     }
 
     /**
-     * Tells whether two intervals share the same end datepoint.
+     * Tells whether two intervals share the same end datepoint
+     * and the same ending boundary type.
      *
      *              [----------)
      *    [--------------------)
@@ -503,7 +505,7 @@ final class Period implements JsonSerializable
      *    [--------------------)
      *               [---------)
      */
-    public function ends(self $interval): bool
+    public function endsBy(self $interval): bool
     {
         return $this->endDate == $interval->endDate
             && $this->boundaryType[1] === $interval->boundaryType[1];

--- a/src/Period.php
+++ b/src/Period.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *
@@ -31,26 +31,53 @@ final class Period implements JsonSerializable
 {
     private const ISO8601_FORMAT = 'Y-m-d\TH:i:s.u\Z';
 
+    public const EXCLUDE_END_INCLUDE_START = '[)';
+
+    public const EXCLUDE_START_INCLUDE_END = '(]';
+
+    public const EXCLUDE_ALL = '()';
+
+    public const EXCLUDE_NONE = '[]';
+
+    private const RANGE_TYPE = [
+        self::EXCLUDE_NONE => 1,
+        self::EXCLUDE_ALL => 1,
+        self::EXCLUDE_END_INCLUDE_START => 1,
+        self::EXCLUDE_START_INCLUDE_END => 1,
+    ];
+
     /**
-     * The starting included datepoint.
+     * The starting datepoint.
      *
      * @var DateTimeImmutable
      */
     private $startDate;
 
     /**
-     * The ending excluded datepoint.
+     * The ending datepoint.
      *
      * @var DateTimeImmutable
      */
     private $endDate;
 
     /**
+     * Range type.
+     *
+     * @var string
+     */
+    private $boundaryType;
+
+
+    /**************************************************
+     * Named constructors
+     **************************************************/
+
+    /**
      * @inheritdoc
      */
     public static function __set_state(array $interval)
     {
-        return new self($interval['startDate'], $interval['endDate']);
+        return new self($interval['startDate'], $interval['endDate'], $interval['boundaryType'] ?? self::EXCLUDE_END_INCLUDE_START);
     }
 
     /**
@@ -59,11 +86,11 @@ final class Period implements JsonSerializable
      * @param mixed $startDate the starting included datepoint
      * @param mixed $duration  a Duration
      */
-    public static function after($startDate, $duration): self
+    public static function after($startDate, $duration, string $boundaryType = self::EXCLUDE_END_INCLUDE_START): self
     {
         $startDate = self::getDatepoint($startDate);
 
-        return new self($startDate, $startDate->add(self::getDuration($duration)));
+        return new self($startDate, $startDate->add(self::getDuration($duration)), $boundaryType);
     }
 
     /**
@@ -100,12 +127,12 @@ final class Period implements JsonSerializable
      * @param mixed $endDate  the ending excluded datepoint
      * @param mixed $duration a Duration
      */
-    public static function before($endDate, $duration): self
+    public static function before($endDate, $duration, string $boundaryType = self::EXCLUDE_END_INCLUDE_START): self
     {
         $endDate = self::getDatepoint($endDate);
         $duration = self::getDuration($duration);
 
-        return new self($endDate->sub($duration), $endDate);
+        return new self($endDate->sub($duration), $endDate, $boundaryType);
     }
 
     /**
@@ -115,12 +142,12 @@ final class Period implements JsonSerializable
      * @param mixed $datepoint a Datepoint
      * @param mixed $duration  a Duration
      */
-    public static function around($datepoint, $duration): self
+    public static function around($datepoint, $duration, string $boundaryType = self::EXCLUDE_END_INCLUDE_START): self
     {
         $datepoint = self::getDatepoint($datepoint);
         $duration = self::getDuration($duration);
 
-        return new self($datepoint->sub($duration), $datepoint->add($duration));
+        return new self($datepoint->sub($duration), $datepoint->add($duration), $boundaryType);
     }
 
     /**
@@ -199,32 +226,38 @@ final class Period implements JsonSerializable
     /**
      * Creates new instance from a DatePeriod.
      */
-    public static function fromDatePeriod(DatePeriod $datePeriod): self
+    public static function fromDatePeriod(DatePeriod $datePeriod, string $boundaryType = self::EXCLUDE_END_INCLUDE_START): self
     {
-        return new self($datePeriod->getStartDate(), $datePeriod->getEndDate());
+        return new self($datePeriod->getStartDate(), $datePeriod->getEndDate(), $boundaryType);
     }
 
     /**
      * Creates a new instance.
      *
-     * @param mixed $startDate the starting included datepoint
-     * @param mixed $endDate   the ending excluded datepoint
+     * @param mixed $startDate the starting datepoint
+     * @param mixed $endDate   the ending datepoint
      *
      * @throws Exception If $startDate is greater than $endDate
      */
-    public function __construct($startDate, $endDate)
+    public function __construct($startDate, $endDate, string $boundaryType = self::EXCLUDE_END_INCLUDE_START)
     {
         $startDate = self::getDatepoint($startDate);
         $endDate = self::getDatepoint($endDate);
         if ($startDate > $endDate) {
             throw new Exception('The ending datepoint must be greater or equal to the starting datepoint');
         }
+
+        if (!isset(self::RANGE_TYPE[$boundaryType])) {
+            throw new Exception('The submitted range type is unknown');
+        }
+
         $this->startDate = $startDate;
         $this->endDate = $endDate;
+        $this->boundaryType = $boundaryType;
     }
 
     /**
-     * Returns the starting included datepoint.
+     * Returns the starting datepoint.
      */
     public function getStartDate(): DateTimeImmutable
     {
@@ -232,7 +265,7 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Returns the ending excluded datepoint.
+     * Returns the ending datepoint.
      */
     public function getEndDate(): DateTimeImmutable
     {
@@ -240,54 +273,16 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Returns the instance duration as expressed in seconds.
+     * Returns the instance range type.
      */
-    public function getTimestampInterval(): float
+    public function getBoundaryType(): string
     {
-        return $this->endDate->getTimestamp() - $this->startDate->getTimestamp();
+        return $this->boundaryType;
     }
 
-    /**
-     * Returns the instance duration as a DateInterval object.
-     */
-    public function getDateInterval(): DateInterval
-    {
-        return $this->startDate->diff($this->endDate);
-    }
-
-    /**
-     * Allows iteration over a set of dates and times,
-     * recurring at regular intervals, over the instance.
-     *
-     * @see http://php.net/manual/en/dateperiod.construct.php
-     *
-     * @param mixed $duration a Duration
-     */
-    public function getDatePeriod($duration, int $option = 0): DatePeriod
-    {
-        return new DatePeriod($this->startDate, self::getDuration($duration), $this->endDate, $option);
-    }
-
-    /**
-     * Allows iteration over a set of dates and times,
-     * recurring at regular intervals, over the instance backwards starting from
-     * the instance ending datepoint.
-     *
-     * @param mixed $duration a Duration
-     */
-    public function getDatePeriodBackwards($duration, int $option = 0): iterable
-    {
-        $duration = self::getDuration($duration);
-        $date = $this->endDate;
-        if ((bool) ($option & DatePeriod::EXCLUDE_START_DATE)) {
-            $date = $this->endDate->sub($duration);
-        }
-
-        while ($date > $this->startDate) {
-            yield $date;
-            $date = $date->sub($duration);
-        }
-    }
+    /**************************************************
+     * String representation
+     **************************************************/
 
     /**
      * Returns the string representation as a ISO8601 interval format.
@@ -335,8 +330,52 @@ final class Period implements JsonSerializable
      */
     public function format(string $format): string
     {
-        return '['.$this->startDate->format($format).', '.$this->endDate->format($format).')';
+        return $this->boundaryType[0]
+            .$this->startDate->format($format)
+            .', '
+            .$this->endDate->format($format)
+            .$this->boundaryType[1];
     }
+
+    /**************************************************
+     * Boundary related methods
+     **************************************************/
+
+    /**
+     * Tells whether the start datepoint is included in the range.
+     */
+    public function isStartDateIncluded(): bool
+    {
+        return '[' === $this->boundaryType[0];
+    }
+
+    /**
+     * Tells whether the start datepoint is excluded from the range.
+     */
+    public function isStartDateExcluded(): bool
+    {
+        return '(' === $this->boundaryType[0];
+    }
+
+    /**
+     * Tells whether the end datepoint is included in the range.
+     */
+    public function isEndDateIncluded(): bool
+    {
+        return ']' === $this->boundaryType[1];
+    }
+
+    /**
+     * Tells whether the end datepoint is excluded from the range.
+     */
+    public function isEndDateExcluded(): bool
+    {
+        return ')' === $this->boundaryType[1];
+    }
+
+    /**************************************************
+     * duration comparison methods
+     **************************************************/
 
     /**
      * Compares two instances according to their duration.
@@ -377,6 +416,11 @@ final class Period implements JsonSerializable
         return -1 === $this->durationCompare($interval);
     }
 
+
+    /**************************************************
+     * relation methods
+     **************************************************/
+
     /**
      * Tells whether two intervals share the same datepoints.
      *
@@ -386,7 +430,8 @@ final class Period implements JsonSerializable
     public function equals(self $interval): bool
     {
         return $this->startDate == $interval->startDate
-            && $this->endDate == $interval->endDate;
+            && $this->endDate == $interval->endDate
+            && $this->boundaryType === $interval->boundaryType;
     }
 
     /**
@@ -400,8 +445,65 @@ final class Period implements JsonSerializable
      */
     public function abuts(self $interval): bool
     {
+        return $this->meets($interval) || $this->metBy($interval);
+    }
+
+    /**
+     * Tells whether the current instance end date meets the interval start date.
+     *
+     * [--------------------)
+     *                      [--------------------)
+     */
+    public function meets(self $interval): bool
+    {
+        return $this->endDate == $interval->startDate
+            && '][' !== $this->boundaryType[1].$interval->boundaryType[0];
+    }
+
+    /**
+     * Tells whether the current instance start date meets the interval end date.
+     *
+     *                      [--------------------)
+     * [--------------------)
+     */
+    public function metBy(self $interval): bool
+    {
         return $this->startDate == $interval->endDate
-            || $this->endDate == $interval->startDate;
+            && '][' !== $interval->boundaryType[1].$this->boundaryType[0];
+    }
+
+    /**
+     * Tells whether two intervals share the same start datepoint.
+     *
+     *    [----------)
+     *    [--------------------)
+     *
+     * or
+     *
+     *    [------------------------------)
+     *    [---------)
+     */
+    public function starts(self $interval): bool
+    {
+        return $this->startDate == $interval->startDate
+            && $this->boundaryType[0] === $interval->boundaryType[0];
+    }
+
+    /**
+     * Tells whether two intervals share the same end datepoint.
+     *
+     *              [----------)
+     *    [--------------------)
+     *
+     * or
+     *
+     *    [------------------------------)
+     *                         [---------)
+     */
+    public function finishes(self $interval): bool
+    {
+        return $this->endDate == $interval->endDate
+            && $this->boundaryType[1] === $interval->boundaryType[1];
     }
 
     /**
@@ -412,26 +514,9 @@ final class Period implements JsonSerializable
      */
     public function overlaps(self $interval): bool
     {
-        return $this->startDate < $interval->endDate
+        return !$this->abuts($interval)
+            && $this->startDate < $interval->endDate
             && $this->endDate > $interval->startDate;
-    }
-
-    /**
-     * Tells whether an interval is entirely after the specified index.
-     * The index can be a DateTimeInterface object or another Period object.
-     *
-     *                          [--------------------)
-     * [--------------------)
-     *
-     * @param mixed $index a datepoint or a Period object
-     */
-    public function isAfter($index): bool
-    {
-        if ($index instanceof self) {
-            return $this->startDate >= $index->endDate;
-        }
-
-        return $this->startDate > self::getDatepoint($index);
     }
 
     /**
@@ -447,10 +532,45 @@ final class Period implements JsonSerializable
     public function isBefore($index): bool
     {
         if ($index instanceof self) {
-            return $this->endDate <= $index->startDate;
+            return $this->endDate < $index->startDate
+                || ($this->endDate == $index->startDate && $this->boundaryType[1] !== $index->boundaryType[0]);
         }
 
-        return $this->endDate <= self::getDatepoint($index);
+        $datepoint = self::getDatepoint($index);
+        return $this->endDate < $datepoint
+            || ($this->endDate == $datepoint && ')' === $this->boundaryType[1]);
+    }
+
+    /**
+     * Tells whether an interval is entirely after the specified index.
+     * The index can be a DateTimeInterface object or another Period object.
+     *
+     *                          [--------------------)
+     * [--------------------)
+     *
+     * @param mixed $index a datepoint or a Period object
+     */
+    public function isAfter($index): bool
+    {
+        if ($index instanceof self) {
+            return $this->startDate > $index->endDate
+                || ($this->startDate == $index->endDate && $this->boundaryType[1] !== $index->boundaryType[0]);
+        }
+
+        $datepoint = self::getDatepoint($index);
+        return $this->startDate > $datepoint
+            || ($this->startDate == $datepoint && '(' === $this->boundaryType[0]);
+    }
+
+    /**
+     * Tells whether an instance is fully contained in the specified interval.
+     *
+     *     [----------)
+     * [--------------------)
+     */
+    public function isDuring(self $interval): bool
+    {
+        return $interval->containsInterval($this);
     }
 
     /**
@@ -466,7 +586,7 @@ final class Period implements JsonSerializable
             return $this->containsInterval($index);
         }
 
-        return $this->containsDatepoint(self::getDatepoint($index));
+        return $this->containsDatepoint(self::getDatepoint($index), $this->boundaryType);
     }
 
     /**
@@ -477,8 +597,25 @@ final class Period implements JsonSerializable
      */
     private function containsInterval(self $interval): bool
     {
-        return $this->containsDatepoint($interval->startDate)
-            && ($interval->endDate >= $this->startDate && $interval->endDate <= $this->endDate);
+        if ($this->startDate < $interval->startDate && $this->endDate > $interval->endDate) {
+            return true;
+        }
+
+        if ($this->startDate == $interval->startDate && $this->endDate == $interval->endDate) {
+            return $this->boundaryType === $interval->boundaryType || '[]' === $this->boundaryType;
+        }
+
+        if ($this->startDate == $interval->startDate) {
+            return ($this->boundaryType[0] === $interval->boundaryType[0] || '[' === $this->boundaryType[0])
+                && $this->containsDatepoint($this->startDate->add($interval->getDateInterval()), $this->boundaryType);
+        }
+
+        if ($this->endDate == $interval->endDate) {
+            return ($this->boundaryType[1] === $interval->boundaryType[1] || ']' === $this->boundaryType[1])
+                && $this->containsDatepoint($this->endDate->sub($interval->getDateInterval()), $this->boundaryType);
+        }
+
+        return false;
     }
 
     /**
@@ -486,9 +623,89 @@ final class Period implements JsonSerializable
      *
      * [------|------------)
      */
-    private function containsDatepoint(DateTimeInterface $datepoint): bool
+    private function containsDatepoint(DateTimeInterface $datepoint, string $boundaryType): bool
     {
-        return $datepoint >= $this->startDate && $datepoint < $this->endDate;
+        switch ($boundaryType) {
+            case self::EXCLUDE_END_INCLUDE_START:
+                return $datepoint >= $this->startDate && $datepoint < $this->endDate;
+            case self::EXCLUDE_START_INCLUDE_END:
+                return $datepoint > $this->startDate && $datepoint <= $this->endDate;
+            case self::EXCLUDE_ALL:
+                return $datepoint > $this->startDate && $datepoint < $this->endDate;
+            default:
+                return $datepoint >= $this->startDate && $datepoint <= $this->endDate;
+        }
+    }
+
+
+    /**************************************************
+     * operation on duration methods
+     **************************************************/
+
+    /**
+     * Returns the instance duration as expressed in seconds.
+     */
+    public function getTimestampInterval(): float
+    {
+        return $this->endDate->getTimestamp() - $this->startDate->getTimestamp();
+    }
+
+    /**
+     * Returns the instance duration as a DateInterval object.
+     */
+    public function getDateInterval(): DateInterval
+    {
+        return $this->startDate->diff($this->endDate);
+    }
+
+    /**
+     * Returns the difference between two instances expressed in seconds.
+     */
+    public function timestampIntervalDiff(self $interval): float
+    {
+        return $this->getTimestampInterval() - $interval->getTimestampInterval();
+    }
+
+    /**
+     * Returns the difference between two instances expressed with a DateInterval object.
+     */
+    public function dateIntervalDiff(self $interval): DateInterval
+    {
+        return $this->endDate->diff($this->startDate->add($interval->getDateInterval()));
+    }
+
+    /**
+     * Allows iteration over a set of dates and times,
+     * recurring at regular intervals, over the instance.
+     *
+     * @see http://php.net/manual/en/dateperiod.construct.php
+     *
+     * @param mixed $duration a Duration
+     */
+    public function getDatePeriod($duration, int $option = 0): DatePeriod
+    {
+        return new DatePeriod($this->startDate, self::getDuration($duration), $this->endDate, $option);
+    }
+
+    /**
+     * Allows iteration over a set of dates and times,
+     * recurring at regular intervals, over the instance backwards starting from
+     * the instance ending datepoint.
+     *
+     * @param mixed $duration a Duration
+     */
+    public function getDatePeriodBackwards($duration, int $option = 0): iterable
+    {
+        $duration = self::getDuration($duration);
+        $date = $this->endDate;
+        if ((bool) ($option & DatePeriod::EXCLUDE_START_DATE)) {
+            $date = $this->endDate->sub($duration);
+        }
+
+        while ($date > $this->startDate) {
+            yield $date;
+            $date = $date->sub($duration);
+        }
     }
 
     /**
@@ -515,7 +732,7 @@ final class Period implements JsonSerializable
                 $endDate = $this->endDate;
             }
 
-            yield new self($startDate, $endDate);
+            yield new self($startDate, $endDate, $this->boundaryType);
         }
     }
 
@@ -543,11 +760,15 @@ final class Period implements JsonSerializable
             if ($startDate < $this->startDate) {
                 $startDate = $this->startDate;
             }
-            yield new self($startDate, $endDate);
+            yield new self($startDate, $endDate, $this->boundaryType);
 
             $endDate = $startDate;
         } while ($endDate > $this->startDate);
     }
+
+    /**************************************************
+     * operation on relation methods
+     **************************************************/
 
     /**
      * Returns the computed intersection between two instances as a new instance.
@@ -566,10 +787,25 @@ final class Period implements JsonSerializable
             throw new Exception('Both '.self::class.' objects should overlaps');
         }
 
-        return new self(
-            ($interval->startDate > $this->startDate) ? $interval->startDate : $this->startDate,
-            ($interval->endDate < $this->endDate) ? $interval->endDate : $this->endDate
-        );
+        $startDate = $this->startDate;
+        $endDate = $this->endDate;
+        $boundaryType = $this->boundaryType;
+        if ($interval->startDate > $this->startDate) {
+            $startDate = $interval->startDate;
+            $boundaryType[0] = $interval->boundaryType[0];
+        }
+
+        if ($interval->endDate < $this->endDate) {
+            $endDate = $interval->endDate;
+            $boundaryType[1] = $interval->boundaryType[1];
+        }
+
+        $intersect = new self($startDate, $endDate, $boundaryType);
+        if ($intersect->equals($this)) {
+            return $this;
+        }
+
+        return $intersect;
     }
 
     /**
@@ -631,28 +867,60 @@ final class Period implements JsonSerializable
             throw new Exception('Both '.self::class.' objects must not overlaps');
         }
 
+        $boundaryType = $this->isEndDateExcluded() ? '[' : '(';
+        $boundaryType .= $interval->isStartDateExcluded() ? ']' : ')';
         if ($interval->startDate > $this->startDate) {
-            return new self($this->endDate, $interval->startDate);
+            return new self($this->endDate, $interval->startDate, $boundaryType);
         }
 
-        return new self($interval->endDate, $this->startDate);
+        return new self($interval->endDate, $this->startDate, $this->boundaryType);
     }
 
     /**
-     * Returns the difference between two instances expressed in seconds.
+     * Merges one or more instances to return a new instance.
+     * The resulting instance represents the largest duration possible.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified new datepoints.
+     *
+     * [--------------------)
+     *          +
+     *                 [----------)
+     *          =
+     * [--------------------------)
+     *
+     *
+     * @param Period ...$intervals
      */
-    public function timestampIntervalDiff(self $interval): float
+    public function merge(self $interval, self ...$intervals): self
     {
-        return $this->getTimestampInterval() - $interval->getTimestampInterval();
+        $intervals[] = $interval;
+        $carry = $this;
+        foreach ($intervals as $interval) {
+            if ($carry->startDate > $interval->startDate) {
+                $carry = new self(
+                    $interval->startDate,
+                    $carry->endDate,
+                    $interval->boundaryType[0].$carry->boundaryType[1]
+                );
+            }
+
+            if ($carry->endDate < $interval->endDate) {
+                $carry = new self(
+                    $carry->startDate,
+                    $interval->endDate,
+                    $carry->boundaryType[0].$interval->boundaryType[1]
+                );
+            }
+        }
+
+        return $carry;
     }
 
-    /**
-     * Returns the difference between two instances expressed with a DateInterval object.
-     */
-    public function dateIntervalDiff(self $interval): DateInterval
-    {
-        return $this->endDate->diff($this->startDate->add($interval->getDateInterval()));
-    }
+
+    /**************************************************
+     * mutation methods
+     **************************************************/
 
     /**
      * Returns an instance with the specified starting datepoint.
@@ -669,7 +937,7 @@ final class Period implements JsonSerializable
             return $this;
         }
 
-        return new self($startDate, $this->endDate);
+        return new self($startDate, $this->endDate, $this->boundaryType);
     }
 
     /**
@@ -687,7 +955,22 @@ final class Period implements JsonSerializable
             return $this;
         }
 
-        return new self($this->startDate, $endDate);
+        return new self($this->startDate, $endDate, $this->boundaryType);
+    }
+
+    /**
+     * Returns an instance with the specified range type.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance with the specified range type.
+     */
+    public function withBoundaryType(string $boundaryType): self
+    {
+        if ($boundaryType === $this->boundaryType) {
+            return $this;
+        }
+
+        return new self($this->startDate, $this->endDate, $boundaryType);
     }
 
     /**
@@ -756,7 +1039,7 @@ final class Period implements JsonSerializable
     public function move($duration): self
     {
         $duration = self::getDuration($duration);
-        $interval = new self($this->startDate->add($duration), $this->endDate->add($duration));
+        $interval = new self($this->startDate->add($duration), $this->endDate->add($duration), $this->boundaryType);
         if ($this->equals($interval)) {
             return $this;
         }
@@ -778,44 +1061,11 @@ final class Period implements JsonSerializable
     public function expand($duration): self
     {
         $duration = self::getDuration($duration);
-        $interval = new self($this->startDate->sub($duration), $this->endDate->add($duration));
+        $interval = new self($this->startDate->sub($duration), $this->endDate->add($duration), $this->boundaryType);
         if ($this->equals($interval)) {
             return $this;
         }
 
         return $interval;
-    }
-
-    /**
-     * Merges one or more instances to return a new instance.
-     * The resulting instance represents the largest duration possible.
-     *
-     * This method MUST retain the state of the current instance, and return
-     * an instance that contains the specified new datepoints.
-     *
-     * [--------------------)
-     *          U
-     *                 [----------)
-     *          =
-     * [--------------------------)
-     *
-     *
-     * @param Period ...$intervals
-     */
-    public function merge(self $interval, self ...$intervals): self
-    {
-        $intervals[] = $interval;
-        $carry = $this;
-        foreach ($intervals as $interval) {
-            if ($carry->startDate > $interval->startDate) {
-                $carry = $carry->startingOn($interval->startDate);
-            }
-
-            if ($carry->endDate < $interval->endDate) {
-                $carry = $carry->endingOn($interval->endDate);
-            }
-        }
-
-        return $carry;
     }
 }

--- a/src/Period.php
+++ b/src/Period.php
@@ -113,7 +113,7 @@ final class Period implements JsonSerializable
     /**
      * Creates new instance from a starting datepoint and a duration.
      *
-     * @param mixed $startDate the starting included datepoint
+     * @param mixed $startDate the starting datepoint
      * @param mixed $duration  a Duration
      */
     public static function after($startDate, $duration, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
@@ -126,7 +126,7 @@ final class Period implements JsonSerializable
     /**
      * Creates new instance from a ending datepoint and a duration.
      *
-     * @param mixed $endDate  the ending excluded datepoint
+     * @param mixed $endDate  the ending datepoint
      * @param mixed $duration a Duration
      */
     public static function before($endDate, $duration, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -62,7 +62,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
      *
      * @return ?Period
      */
-    public function getBoundaries(): ?Period
+    public function boundaries(): ?Period
     {
         $period = reset($this->intervals);
         if (false === $period) {
@@ -75,7 +75,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     /**
      * Returns the gaps inside the instance.
      */
-    public function getGaps(): self
+    public function gaps(): self
     {
         $sequence = new self();
         $interval = null;
@@ -108,7 +108,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     /**
      * Returns the intersections inside the instance.
      */
-    public function getIntersections(): self
+    public function intersections(): self
     {
         $sequence = new self();
         $current = null;
@@ -138,9 +138,9 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     }
 
     /**
-     * Returns the uninon inside the instance.
+     * Returns the unions inside the instance.
      */
-    public function getUnions(): self
+    public function unions(): self
     {
         $sequence = new self();
         foreach ($this->sorted([$this, 'sortByStartDate']) as $period) {
@@ -164,6 +164,49 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
         }
 
         return $sequence;
+    }
+
+    /**
+     * Returns the sequence boundaries as a Period instance.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.4.0
+     * @see        ::boundaries
+     *
+     * If the sequence contains no interval null is returned.
+     *
+     * @return ?Period
+     */
+    public function getBoundaries(): ?Period
+    {
+        return $this->boundaries();
+    }
+
+    /**
+     * Returns the intersections inside the instance.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.4.0
+     * @see        ::intersections
+     */
+    public function getIntersections(): self
+    {
+        return $this->intersections();
+    }
+
+    /**
+     * Returns the gaps inside the instance.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 4.4.0
+     * @see        ::gaps
+     */
+    public function getGaps(): self
+    {
+        return $this->gaps();
     }
 
     /**

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *
@@ -132,6 +132,35 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
             if (!$isContained) {
                 $current = $period;
             }
+        }
+
+        return $sequence;
+    }
+
+    /**
+     * Returns the uninon inside the instance.
+     */
+    public function getUnions(): self
+    {
+        $sequence = new self();
+        foreach ($this->sorted([$this, 'sortByStartDate']) as $period) {
+            if ($sequence->isEmpty()) {
+                $sequence->push($period);
+                continue;
+            }
+
+            $index = $sequence->count() - 1;
+            $interval = $sequence->get($index);
+            if ($interval->overlaps($period) || $interval->abuts($period)) {
+                $sequence->set($index, $interval->merge($period));
+                continue;
+            }
+
+            $sequence->push($period);
+        }
+
+        if ($sequence->intervals === $this->intervals) {
+            return $this;
         }
 
         return $sequence;

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/DatepointTest.php
+++ b/tests/DatepointTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *
@@ -14,25 +14,9 @@ namespace LeagueTest\Period;
 use DateTime;
 use DateTimeImmutable;
 use League\Period\Datepoint;
-use PHPUnit\Framework\TestCase;
 
 class DatepointTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    protected $timezone;
-
-    public function setUp(): void
-    {
-        $this->timezone = date_default_timezone_get();
-    }
-
-    public function tearDown(): void
-    {
-        date_default_timezone_set($this->timezone);
-    }
-
     public function testCreateFromFormat(): void
     {
         self::assertInstanceOf(Datepoint::class, Datepoint::createFromFormat('Y-m-d', '2018-12-01'));

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *
@@ -14,25 +14,9 @@ namespace LeagueTest\Period;
 use DateInterval;
 use League\Period\Duration;
 use League\Period\Period;
-use PHPUnit\Framework\TestCase;
 
 class DurationTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    protected $timezone;
-
-    public function setUp(): void
-    {
-        $this->timezone = date_default_timezone_get();
-    }
-
-    public function tearDown(): void
-    {
-        date_default_timezone_set($this->timezone);
-    }
-
     public function testCreateFromDateString(): void
     {
         $duration = Duration::createFromDateString('+1 DAY');

--- a/tests/ExtendedDate.php
+++ b/tests/ExtendedDate.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *
@@ -19,7 +19,6 @@ use DateTimeInterface;
 use Exception as PhpException;
 use League\Period\Duration;
 use League\Period\Exception;
-use PHPUnit\Framework\TestCase;
 use TypeError;
 use function get_object_vars;
 use function League\Period\datepoint;

--- a/tests/Period/BoundaryTest.php
+++ b/tests/Period/BoundaryTest.php
@@ -33,10 +33,10 @@ class BoundaryTest extends TestCase
         bool $endExcluded
     ): void {
         self::assertSame($rangeType, $interval->getBoundaryType());
-        self::assertSame($startIncluded, $interval->isStartDateIncluded());
-        self::assertSame($startExcluded, $interval->isStartDateExcluded());
-        self::assertSame($endIncluded, $interval->isEndDateIncluded());
-        self::assertSame($endExcluded, $interval->isEndDateExcluded());
+        self::assertSame($startIncluded, $interval->isStartIncluded());
+        self::assertSame($startExcluded, $interval->isStartExcluded());
+        self::assertSame($endIncluded, $interval->isEndIncluded());
+        self::assertSame($endExcluded, $interval->isEndExcluded());
     }
 
     public function providerGetRangType(): array

--- a/tests/Period/BoundaryTest.php
+++ b/tests/Period/BoundaryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period\Period;
+
+use DateTime;
+use League\Period\Exception;
+use League\Period\Period;
+use LeagueTest\Period\TestCase;
+
+/**
+ * @coversDefaultClass \League\Period\Period
+ */
+class BoundaryTest extends TestCase
+{
+    /**
+     * @dataProvider providerGetRangType
+     */
+    public function testGetRangeType(
+        Period $interval,
+        string $rangeType,
+        bool $startIncluded,
+        bool $startExcluded,
+        bool $endIncluded,
+        bool $endExcluded
+    ): void {
+        self::assertSame($rangeType, $interval->getBoundaryType());
+        self::assertSame($startIncluded, $interval->isStartDateIncluded());
+        self::assertSame($startExcluded, $interval->isStartDateExcluded());
+        self::assertSame($endIncluded, $interval->isEndDateIncluded());
+        self::assertSame($endExcluded, $interval->isEndDateExcluded());
+    }
+
+    public function providerGetRangType(): array
+    {
+        return [
+            'left open right close' => [
+                'interval' => Period::fromDay(2012, 8, 12),
+                'rangeType' => Period::INCLUDE_START_EXCLUDE_END,
+                'startIncluded' => true,
+                'startExcluded' => false,
+                'endIncluded' => false,
+                'endExcluded' => true,
+            ],
+            'left close right open' => [
+                'interval' => Period::around('2012-08-12', '1 HOUR', Period::EXCLUDE_START_INCLUDE_END),
+                'rangeType' => Period::EXCLUDE_START_INCLUDE_END,
+                'startIncluded' => false,
+                'startExcluded' => true,
+                'endIncluded' => true,
+                'endExcluded' => false,
+            ],
+            'left open right open' => [
+                'interval' => Period::after('2012-08-12', '1 DAY', Period::INCLUDE_ALL),
+                'rangeType' => Period::INCLUDE_ALL,
+                'startIncluded' => true,
+                'startExcluded' => false,
+                'endIncluded' => true,
+                'endExcluded' => false,
+            ],
+            'left close right close' => [
+                'interval' => Period::before('2012-08-12', '1 WEEK', Period::EXCLUDE_ALL),
+                'rangeType' => Period::EXCLUDE_ALL,
+                'startIncluded' => false,
+                'startExcluded' => true,
+                'endIncluded' => false,
+                'endExcluded' => true,
+            ],
+        ];
+    }
+
+    public function testWithBoundaryType(): void
+    {
+        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
+        $altInterval = $interval->withBoundaryType(Period::EXCLUDE_ALL);
+        self::assertEquals($interval->getDateInterval(), $interval->getDateInterval());
+        self::assertNotEquals($interval->getBoundaryType(), $altInterval->getBoundaryType());
+        self::assertSame($interval, $interval->withBoundaryType(Period::INCLUDE_START_EXCLUDE_END));
+    }
+
+    public function testWithBoundaryTypeFails(): void
+    {
+        self::expectException(Exception::class);
+        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
+        $altInterval = $interval->withBoundaryType('foobar');
+    }
+}

--- a/tests/Period/ConstructorTest.php
+++ b/tests/Period/ConstructorTest.php
@@ -1,0 +1,327 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period\Period;
+
+use DateInterval;
+use DatePeriod;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception as PhpException;
+use League\Period\Datepoint;
+use League\Period\Duration;
+use League\Period\Exception;
+use League\Period\Period;
+use LeagueTest\Period\ExtendedDate;
+use LeagueTest\Period\TestCase;
+use TypeError;
+
+/**
+ * @coversDefaultClass \League\Period\Period
+ */
+class ConstructorTest extends TestCase
+{
+    public function testConstructorThrowExceptionIfUnknownBoundPeriodDay(): void
+    {
+        self::expectException(Exception::class);
+        new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'), 'foobar');
+    }
+
+    public function testConstructorThrowTypeError(): void
+    {
+        self::expectException(TypeError::class);
+        new Period(new DateTime(), []);
+    }
+
+    public function testSetState(): void
+    {
+        $period = new Period('2014-05-01', '2014-05-08');
+        $generatedPeriod = eval('return '.var_export($period, true).';');
+        self::assertTrue($generatedPeriod->equals($period));
+        self::assertEquals($generatedPeriod, $period);
+    }
+
+    public function testConstructor(): void
+    {
+        $period = new Period('2014-05-01', '2014-05-08');
+        self::assertEquals(new DateTimeImmutable('2014-05-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-05-08'), $period->getEndDate());
+    }
+
+    public function testConstructorWithMicroSecondsSucceed(): void
+    {
+        $period = new Period('2014-05-01 00:00:00', '2014-05-01 00:00:00');
+        self::assertEquals(new DateInterval('PT0S'), $period->getDateInterval());
+    }
+
+    public function testConstructorThrowException(): void
+    {
+        self::expectException(Exception::class);
+        new Period(
+            new DateTime('2014-05-01', new DateTimeZone('Europe/Paris')),
+            new DateTime('2014-05-01', new DateTimeZone('Africa/Nairobi'))
+        );
+    }
+
+    public function testConstructorWithDateTimeInterface(): void
+    {
+        $start = '2014-05-01';
+        $end = new DateTime('2014-05-08');
+        $period = new Period($start, $end);
+        self::assertSame($start, $period->getStartDate()->format('Y-m-d'));
+        self::assertEquals($end, $period->getEndDate());
+    }
+
+    /**
+     * @dataProvider provideIntervalAfterData
+     *
+     * @param int|DateInterval|string $duration
+     */
+    public function testIntervalAfter(string $startDate, string $endDate, $duration): void
+    {
+        $period = Period::after($startDate, $duration);
+        self::assertEquals(new DateTimeImmutable($startDate), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable($endDate), $period->getEndDate());
+    }
+
+    public function provideIntervalAfterData(): array
+    {
+        return [
+            'usingAString' => [
+                '2015-01-01', '2015-01-02', '+1 DAY',
+            ],
+            'usingAnInt' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', 3600,
+            ],
+            'usingADateInterval' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', new DateInterval('PT1H'),
+            ],
+            'usingAFloatWithNoMicroseconds' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', 3600.0,
+            ],
+            'usingAnInterval' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', Datepoint::create('2012-01-03 12:00:00')->getHour(),
+            ],
+        ];
+    }
+
+    public function testIntervalAfterWithInvalidInteger(): void
+    {
+        self::expectException(PhpException::class);
+        Period::after('2014-01-01', -1);
+    }
+
+    public function testIntervalAfterFailedWithOutofRangeInterval(): void
+    {
+        self::expectException(Exception::class);
+        Period::after(new DateTime('2012-01-12'), '-1 DAY');
+    }
+
+    public function testIntervalAfterFailedWithInvalidInterval(): void
+    {
+        self::expectException(TypeError::class);
+        Period::after(new DateTime('2012-01-12'), []);
+    }
+
+    /**
+     * @dataProvider intervalBeforeProviderData
+     *
+     * @param int|DateInterval|string $duration
+     */
+    public function testIntervalBefore(string $startDate, string $endDate, $duration): void
+    {
+        $period = Period::before($endDate, $duration);
+        self::assertEquals(new DateTimeImmutable($startDate), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable($endDate), $period->getEndDate());
+    }
+
+    public function intervalBeforeProviderData(): array
+    {
+        return [
+            'usingAString' => [
+                '2015-01-01', '2015-01-02', '+1 DAY',
+            ],
+            'usingAnInt' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', 3600,
+            ],
+            'usingADateInterval' => [
+                '2015-01-01 10:00:00', '2015-01-01 11:00:00', new DateInterval('PT1H'),
+            ],
+        ];
+    }
+
+    public function testIntervalBeforeFailedWithOutofRangeInterval(): void
+    {
+        self::expectException(Exception::class);
+        Period::before(new DateTime('2012-01-12'), '-1 DAY');
+    }
+
+    public function testIntervalAround(): void
+    {
+        $date = '2012-06-05';
+        $duration = '1 WEEK';
+
+        $period = Period::around($date, $duration);
+        self::assertTrue($period->contains($date));
+        self::assertEquals(Datepoint::create($date)->sub(Duration::create($duration)), $period->getStartDate());
+        self::assertEquals(Datepoint::create($date)->add(Duration::create($duration)), $period->getEndDate());
+    }
+
+    public function testIntervalAroundThrowsException(): void
+    {
+        self::expectException(Exception::class);
+        Period::around(new DateTime('2012-06-05'), '-1 DAY');
+    }
+
+    public function testIntervalFromDatePeriod(): void
+    {
+        $datePeriod = new DatePeriod(
+            new DateTime('2016-05-16T00:00:00Z'),
+            new DateInterval('P1D'),
+            new DateTime('2016-05-20T00:00:00Z')
+        );
+        $period = Period::fromDatePeriod($datePeriod);
+        self::assertEquals($datePeriod->getStartDate(), $period->getStartDate());
+        self::assertEquals($datePeriod->getEndDate(), $period->getEndDate());
+    }
+
+    public function testIntervalFromDatePeriodThrowsException(): void
+    {
+        self::expectException(TypeError::class);
+        Period::fromDatePeriod(new DatePeriod('R4/2012-07-01T00:00:00Z/P7D'));
+    }
+
+    public function testIsoWeek(): void
+    {
+        $period = Period::fromIsoWeek(2014, 3);
+        self::assertEquals(new DateTimeImmutable('2014-01-13'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-01-20'), $period->getEndDate());
+    }
+
+    public function testIsoWeekWithDefaultArgument(): void
+    {
+        self::assertTrue(Period::fromIsoWeek(2014)->equals(Period::fromIsoWeek(2014, 1)));
+    }
+
+    public function testMonth(): void
+    {
+        $period = Period::fromMonth(2014, 3);
+        self::assertEquals(new DateTimeImmutable('2014-03-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-04-01'), $period->getEndDate());
+    }
+
+    public function testMonthWithDefaultArgument(): void
+    {
+        self::assertTrue(Period::fromMonth(2014)->equals(Period::fromMonth(2014, 1)));
+    }
+
+    public function testQuarter(): void
+    {
+        $period = Period::fromQuarter(2014, 3);
+        self::assertEquals(new DateTimeImmutable('2014-07-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-10-01'), $period->getEndDate());
+    }
+
+    public function testQuarterWithDefaultArgument(): void
+    {
+        self::assertEquals(Period::fromQuarter(2014), Period::fromQuarter(2014, 1));
+    }
+
+    public function testSemester(): void
+    {
+        $period = Period::fromSemester(2014, 2);
+        self::assertEquals(new DateTimeImmutable('2014-07-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2015-01-01'), $period->getEndDate());
+    }
+
+    public function testSemesterWithDefaultArgument(): void
+    {
+        self::assertEquals(Period::fromSemester(2014), Period::fromSemester(2014, 1));
+    }
+
+    public function testYear(): void
+    {
+        $period = Period::fromYear(2014);
+        self::assertEquals(new DateTimeImmutable('2014-01-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2015-01-01'), $period->getEndDate());
+    }
+
+    public function testISOYear(): void
+    {
+        $period = Period::fromIsoYear(2014);
+        $interval = Datepoint::create('2014-06-25')->getIsoYear();
+        self::assertEquals(new DateTimeImmutable('2013-12-30'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-12-29'), $period->getEndDate());
+        self::assertTrue($period->equals($interval));
+    }
+
+    public function testDay(): void
+    {
+        $period = Datepoint::create(new ExtendedDate('2008-07-01T22:35:17.123456+08:00'))->getDay();
+        self::assertEquals(new DateTimeImmutable('2008-07-01T00:00:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2008-07-02T00:00:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+    }
+
+    public function testAlternateDay(): void
+    {
+        $period = Datepoint::create('2008-07-01')->getDay();
+        $alt_period = Period::fromDay(2008, 7, 1);
+        self::assertEquals($period, $alt_period);
+    }
+
+    public function testDayWithDefaultArgument(): void
+    {
+        self::assertEquals(Period::fromDay(2008), Period::fromDay(2008, 1, 1));
+        self::assertEquals(Period::fromDay(2008, 1), Period::fromDay(2008, 1, 1));
+    }
+
+    public function testHour(): void
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = Datepoint::create($today)->getHour();
+        self::assertEquals(new DateTimeImmutable('2008-07-01T22:00:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2008-07-01T23:00:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+    }
+
+    public function testCreateFromWithDateTimeInterface(): void
+    {
+        self::assertTrue(Datepoint::create('2008W27')->getIsoWeek()->equals(Period::fromIsoWeek(2008, 27)));
+        self::assertTrue(Datepoint::create('2008-07')->getMonth()->equals(Period::fromMonth(2008, 7)));
+        self::assertTrue(Datepoint::create('2008-02')->getQuarter()->equals(Period::fromQuarter(2008, 1)));
+        self::assertTrue(Datepoint::create('2008-10')->getSemester()->equals(Period::fromSemester(2008, 2)));
+        self::assertTrue(Datepoint::create('2008-01')->getYear()->equals(Period::fromYear(2008)));
+    }
+
+    public function testMonthWithDateTimeInterface(): void
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = Datepoint::create($today)->getMonth();
+        self::assertEquals(new DateTimeImmutable('2008-07-01T00:00:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2008-08-01T00:00:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+    }
+
+    public function testYearWithDateTimeInterface(): void
+    {
+        $today = new ExtendedDate('2008-07-01T22:35:17.123456+08:00');
+        $period = Datepoint::create($today)->getYear();
+        self::assertEquals(new DateTimeImmutable('2008-01-01T00:00:00+08:00'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2009-01-01T00:00:00+08:00'), $period->getEndDate());
+        self::assertEquals('+08:00', $period->getStartDate()->format('P'));
+        self::assertEquals('+08:00', $period->getEndDate()->format('P'));
+    }
+}

--- a/tests/Period/IntervalRelationTest.php
+++ b/tests/Period/IntervalRelationTest.php
@@ -408,7 +408,7 @@ class IntervalRelationTest extends TestCase
      */
     public function testStarts(Period $interval1, Period $interval2, bool $expected): void
     {
-        self::assertSame($expected, $interval1->starts($interval2));
+        self::assertSame($expected, $interval1->startsBy($interval2));
     }
 
     public function startsDataProvider(): array
@@ -442,7 +442,7 @@ class IntervalRelationTest extends TestCase
      */
     public function testFinishes(Period $interval1, Period $interval2, bool $expected): void
     {
-        self::assertSame($expected, $interval1->ends($interval2));
+        self::assertSame($expected, $interval1->endsBy($interval2));
     }
 
     public function finishesDataProvider(): array

--- a/tests/Period/IntervalRelationTest.php
+++ b/tests/Period/IntervalRelationTest.php
@@ -944,11 +944,11 @@ class IntervalRelationTest extends TestCase
                 $intersect = $interval0->intersect($interval1);
 
                 if (null !== $diff1) {
-                    self::assertTrue($diff1->borderOnStart($intersect));
+                    self::assertTrue($diff1->bordersOnStart($intersect));
                 }
 
                 if (null !== $diff2) {
-                    self::assertTrue($diff2->borderOnEnd($intersect));
+                    self::assertTrue($diff2->bordersOnEnd($intersect));
                 }
 
                 $seq = new Sequence(...array_filter([$diff1, $diff2, $intersect]));

--- a/tests/Period/IntervalRelationTest.php
+++ b/tests/Period/IntervalRelationTest.php
@@ -9,18 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace LeagueTest\Period;
+namespace LeagueTest\Period\Period;
 
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use League\Period\Exception;
 use League\Period\Period;
+use LeagueTest\Period\TestCase;
 
 /**
  * @coversDefaultClass \League\Period\Period
  */
-class PeriodComparisonTest extends TestCase
+class IntervalRelationTest extends TestCase
 {
     /**
      * @dataProvider isBeforeProvider
@@ -470,35 +471,6 @@ class PeriodComparisonTest extends TestCase
     }
 
     /**
-     * @dataProvider durationCompareDataProvider
-     */
-    public function testDurationCompare(Period $interval1, Period $interval2, int $expected): void
-    {
-        self::assertSame($expected, $interval1->durationCompare($interval2));
-    }
-
-    public function durationCompareDataProvider(): array
-    {
-        return [
-            'duration less than' => [
-                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15')),
-                new Period(new DateTime('2013-01-01'), new DateTime('2013-01-16')),
-                -1,
-            ],
-            'duration greater than' => [
-                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15')),
-                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-07')),
-                1,
-            ],
-            'duration equals with microsecond' => [
-                new Period(new DateTime('2012-01-01 00:00:00'), new DateTime('2012-01-03 00:00:00.123456')),
-                new Period(new DateTime('2012-02-02 00:00:00'), new DateTime('2012-02-04 00:00:00.123456')),
-                0,
-            ],
-        ];
-    }
-
-    /**
      * @dataProvider equalsDataProvider
      */
     public function testEquals(Period  $interval1, Period $interval2, bool $expected): void
@@ -642,37 +614,5 @@ class PeriodComparisonTest extends TestCase
         self::assertSame(3600.0, $diff1->getTimestampInterval());
         self::assertSame(3600.0, $diff2->getTimestampInterval());
         self::assertEquals($alt->diff($period), $period->diff($alt));
-    }
-
-    /**
-     * @dataProvider durationCompareInnerMethodsDataProvider
-     */
-    public function testDurationCompareInnerMethods(Period $period1, Period $period2, string $method, bool $expected): void
-    {
-        self::assertSame($expected, $period1->$method($period2));
-    }
-
-    public function durationCompareInnerMethodsDataProvider(): array
-    {
-        return [
-            'testDurationLessThan' => [
-                new Period('2012-01-01', '2012-01-07'),
-                new Period('2013-01-01', '2013-02-01'),
-                'durationLessThan',
-                true,
-            ],
-            'testDurationGreaterThanReturnsTrue' => [
-                new Period('2012-01-01', '2012-02-01'),
-                new Period('2012-01-01', '2012-01-07'),
-                'durationGreaterThan',
-                true,
-            ],
-            'testdurationEqualsReturnsTrueWithMicroseconds' => [
-                new Period('2012-01-01 00:00:00', '2012-01-03 00:00:00'),
-                new Period('2012-02-02 00:00:00', '2012-02-04 00:00:00'),
-                'durationEquals',
-                true,
-            ],
-        ];
     }
 }

--- a/tests/Period/IntervalRelationTest.php
+++ b/tests/Period/IntervalRelationTest.php
@@ -16,6 +16,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use League\Period\Exception;
 use League\Period\Period;
+use League\Period\Sequence;
 use LeagueTest\Period\TestCase;
 
 /**
@@ -520,7 +521,7 @@ class IntervalRelationTest extends TestCase
     }
 
     /**
-     * @dataProvider gapBoundaryResultProvider
+     * @dataProvider intersectBoundaryResultProvider
      */
     public function testIntersectBoundaryTypeResult(string $boundary1, string $boundary2, string $expected): void
     {
@@ -528,6 +529,94 @@ class IntervalRelationTest extends TestCase
         $interval1 = new Period('2014-05-01', '2014-08-01', $boundary2);
         self::assertSame($expected, $interval0->intersect($interval1)->getBoundaryType());
     }
+
+    public function intersectBoundaryResultProvider(): array
+    {
+        return [
+            '() + ()' => [
+                'boundary1' => Period::EXCLUDE_ALL,
+                'boundary2' => Period::EXCLUDE_ALL,
+                'expected' => Period::EXCLUDE_ALL,
+            ],
+            '() + []' => [
+                'boundary1' => Period::EXCLUDE_ALL,
+                'boundary2' => Period::INCLUDE_ALL,
+                'expected' => Period::INCLUDE_START_EXCLUDE_END,
+            ],
+            '() + [)' => [
+                'boundary1' => Period::EXCLUDE_ALL,
+                'boundary2' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected' => Period::INCLUDE_START_EXCLUDE_END,
+            ],
+            '() + (]' => [
+                'boundary1' => Period::EXCLUDE_ALL,
+                'boundary2' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected' => Period::EXCLUDE_ALL,
+            ],
+            '[] + []' => [
+                'boundary1' => Period::INCLUDE_ALL,
+                'boundary2' => Period::INCLUDE_ALL,
+                'expected' => Period::INCLUDE_ALL,
+            ],
+            '[] + [)' => [
+                'boundary1' => Period::INCLUDE_ALL,
+                'boundary2' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected' => Period::INCLUDE_ALL,
+            ],
+            '[] + (]' => [
+                'boundary1' => Period::INCLUDE_ALL,
+                'boundary2' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected' => Period::EXCLUDE_START_INCLUDE_END,
+            ],
+            '[] + ()' => [
+                'boundary1' => Period::INCLUDE_ALL,
+                'boundary2' => Period::EXCLUDE_ALL,
+                'expected' => Period::EXCLUDE_START_INCLUDE_END,
+            ],
+            '[) + ()' => [
+                'boundary1' => Period::INCLUDE_START_EXCLUDE_END,
+                'boundary2' => Period::EXCLUDE_ALL,
+                'expected' => Period::EXCLUDE_ALL,
+            ],
+            '[) + []' => [
+                'boundary1' => Period::INCLUDE_START_EXCLUDE_END,
+                'boundary2' => Period::INCLUDE_ALL,
+                'expected' => Period::INCLUDE_START_EXCLUDE_END,
+            ],
+            '[) + (]' => [
+                'boundary1' => Period::INCLUDE_START_EXCLUDE_END,
+                'boundary2' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected' => Period::EXCLUDE_ALL,
+            ],
+            '[) + [)' => [
+                'boundary1' => Period::INCLUDE_START_EXCLUDE_END,
+                'boundary2' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected' => Period::INCLUDE_START_EXCLUDE_END,
+            ],
+            '(] + ()' => [
+                'boundary1' => Period::EXCLUDE_START_INCLUDE_END,
+                'boundary2' => Period::EXCLUDE_ALL,
+                'expected' => Period::EXCLUDE_START_INCLUDE_END,
+            ],
+            '(] + []' => [
+                'boundary1' => Period::EXCLUDE_START_INCLUDE_END,
+                'boundary2' => Period::INCLUDE_ALL,
+                'expected' => Period::INCLUDE_ALL,
+            ],
+            '(] + (]' => [
+                'boundary1' => Period::EXCLUDE_START_INCLUDE_END,
+                'boundary2' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected' => Period::EXCLUDE_START_INCLUDE_END,
+            ],
+            '(] + [)' => [
+                'boundary1' => Period::EXCLUDE_START_INCLUDE_END,
+                'boundary2' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected' => Period::INCLUDE_ALL,
+            ],
+        ];
+    }
+
+
 
     public function testGap(): void
     {
@@ -749,62 +838,62 @@ class IntervalRelationTest extends TestCase
             '() + ()' => [
                 'boundary1' => Period::EXCLUDE_ALL,
                 'boundary2' => Period::EXCLUDE_ALL,
-                'expected1' => Period::INCLUDE_START_EXCLUDE_END,
-                'expected2' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected1' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected2' => Period::INCLUDE_START_EXCLUDE_END,
             ],
             '() + []' => [
                 'boundary1' => Period::EXCLUDE_ALL,
                 'boundary2' => Period::INCLUDE_ALL,
-                'expected1' => Period::INCLUDE_ALL,
-                'expected2' => Period::EXCLUDE_ALL,
+                'expected1' => Period::EXCLUDE_ALL,
+                'expected2' => Period::INCLUDE_ALL,
             ],
             '() + [)' => [
                 'boundary1' => Period::EXCLUDE_ALL,
                 'boundary2' => Period::INCLUDE_START_EXCLUDE_END,
-                'expected1' => Period::INCLUDE_START_EXCLUDE_END,
-                'expected2' => Period::EXCLUDE_ALL,
+                'expected1' => Period::EXCLUDE_ALL,
+                'expected2' => Period::INCLUDE_START_EXCLUDE_END,
             ],
             '() + (]' => [
                 'boundary1' => Period::EXCLUDE_ALL,
                 'boundary2' => Period::EXCLUDE_START_INCLUDE_END,
-                'expected1' => Period::INCLUDE_ALL,
-                'expected2' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected1' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected2' => Period::INCLUDE_ALL,
             ],
             '[] + []' => [
                 'boundary1' => Period::INCLUDE_ALL,
                 'boundary2' => Period::INCLUDE_ALL,
-                'expected1' => Period::EXCLUDE_START_INCLUDE_END,
-                'expected2' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected1' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected2' => Period::EXCLUDE_START_INCLUDE_END,
             ],
             '[] + [)' => [
                 'boundary1' => Period::INCLUDE_ALL,
                 'boundary2' => Period::INCLUDE_START_EXCLUDE_END,
-                'expected1' => Period::EXCLUDE_ALL,
-                'expected2' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected1' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected2' => Period::EXCLUDE_ALL,
             ],
             '[] + (]' => [
                 'boundary1' => Period::INCLUDE_ALL,
                 'boundary2' => Period::EXCLUDE_START_INCLUDE_END,
-                'expected1' => Period::EXCLUDE_START_INCLUDE_END,
-                'expected2' => Period::INCLUDE_ALL,
+                'expected1' => Period::INCLUDE_ALL,
+                'expected2' => Period::EXCLUDE_START_INCLUDE_END,
             ],
             '[] + ()' => [
                 'boundary1' => Period::INCLUDE_ALL,
                 'boundary2' => Period::EXCLUDE_ALL,
-                'expected1' => Period::EXCLUDE_ALL,
-                'expected2' => Period::INCLUDE_ALL,
+                'expected1' => Period::INCLUDE_ALL,
+                'expected2' => Period::EXCLUDE_ALL,
             ],
             '[) + ()' => [
                 'boundary1' => Period::INCLUDE_START_EXCLUDE_END,
                 'boundary2' => Period::EXCLUDE_ALL,
-                'expected1' => Period::INCLUDE_START_EXCLUDE_END,
-                'expected2' => Period::INCLUDE_ALL,
+                'expected1' => Period::INCLUDE_ALL,
+                'expected2' => Period::INCLUDE_START_EXCLUDE_END,
             ],
             '[) + []' => [
                 'boundary1' => Period::INCLUDE_START_EXCLUDE_END,
                 'boundary2' => Period::INCLUDE_ALL,
-                'expected1' => Period::INCLUDE_ALL,
-                'expected2' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected1' => Period::INCLUDE_START_EXCLUDE_END,
+                'expected2' => Period::INCLUDE_ALL,
             ],
             '[) + (]' => [
                 'boundary1' => Period::INCLUDE_START_EXCLUDE_END,
@@ -821,14 +910,14 @@ class IntervalRelationTest extends TestCase
             '(] + ()' => [
                 'boundary1' => Period::EXCLUDE_START_INCLUDE_END,
                 'boundary2' => Period::EXCLUDE_ALL,
-                'expected1' => Period::EXCLUDE_ALL,
-                'expected2' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected1' => Period::EXCLUDE_START_INCLUDE_END,
+                'expected2' => Period::EXCLUDE_ALL,
             ],
             '(] + []' => [
                 'boundary1' => Period::EXCLUDE_START_INCLUDE_END,
                 'boundary2' => Period::INCLUDE_ALL,
-                'expected1' => Period::EXCLUDE_START_INCLUDE_END,
-                'expected2' => Period::EXCLUDE_ALL,
+                'expected1' => Period::EXCLUDE_ALL,
+                'expected2' => Period::EXCLUDE_START_INCLUDE_END,
             ],
             '(] + (]' => [
                 'boundary1' => Period::EXCLUDE_START_INCLUDE_END,
@@ -843,5 +932,31 @@ class IntervalRelationTest extends TestCase
                 'expected2' => Period::EXCLUDE_ALL,
             ],
         ];
+    }
+
+    public function testDiffAndIntersect(): void
+    {
+        foreach (['[]', '[)', '()', '(]'] as $bound1) {
+            foreach (['[]', '[)', '()', '(]'] as $bound2) {
+                $interval0 = new Period('2014-03-01', '2014-06-01', $bound1);
+                $interval1 = new Period('2014-05-01', '2014-08-01', $bound2);
+                [$diff1, $diff2] = $interval0->diff($interval1);
+                $intersect = $interval0->intersect($interval1);
+
+                if (null !== $diff1) {
+                    self::assertTrue($diff1->borderOnStart($intersect));
+                }
+
+                if (null !== $diff2) {
+                    self::assertTrue($diff2->borderOnEnd($intersect));
+                }
+
+                $seq = new Sequence(...array_filter([$diff1, $diff2, $intersect]));
+                $boundaries = $seq->getBoundaries();
+                if (null !== $boundaries) {
+                    self::assertTrue($boundaries->equals($interval0->merge($interval1)));
+                }
+            }
+        }
     }
 }

--- a/tests/Period/IntervalRelationTest.php
+++ b/tests/Period/IntervalRelationTest.php
@@ -442,7 +442,7 @@ class IntervalRelationTest extends TestCase
      */
     public function testFinishes(Period $interval1, Period $interval2, bool $expected): void
     {
-        self::assertSame($expected, $interval1->finishes($interval2));
+        self::assertSame($expected, $interval1->ends($interval2));
     }
 
     public function finishesDataProvider(): array

--- a/tests/Period/ModificationTest.php
+++ b/tests/Period/ModificationTest.php
@@ -9,19 +9,20 @@
  * file that was distributed with this source code.
  */
 
-namespace LeagueTest\Period;
+namespace LeagueTest\Period\Period;
 
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use League\Period\Exception;
 use League\Period\Period;
+use LeagueTest\Period\TestCase;
 use TypeError;
 
 /**
  * @coversDefaultClass \League\Period\Period
  */
-class PeriodModificationTest extends TestCase
+class ModificationTest extends TestCase
 {
     public function testStartingOn(): void
     {
@@ -55,22 +56,6 @@ class PeriodModificationTest extends TestCase
         self::expectException(Exception::class);
         $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
         $interval->endingOn(new DateTime('2012-03-02'));
-    }
-
-    public function testWithBoundaryType(): void
-    {
-        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
-        $altInterval = $interval->withBoundaryType(Period::EXCLUDE_ALL);
-        self::assertEquals($interval->getDateInterval(), $interval->getDateInterval());
-        self::assertNotEquals($interval->getBoundaryType(), $altInterval->getBoundaryType());
-        self::assertSame($interval, $interval->withBoundaryType(Period::INCLUDE_START_EXCLUDE_END));
-    }
-
-    public function testWithBoundaryTypeFails(): void
-    {
-        self::expectException(Exception::class);
-        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
-        $altInterval = $interval->withBoundaryType('foobar');
     }
 
     public function testExpand(): void

--- a/tests/Period/StringRepresentationTest.php
+++ b/tests/Period/StringRepresentationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period\Period;
+
+use DateTimeImmutable;
+use League\Period\Period;
+use LeagueTest\Period\TestCase;
+
+/**
+ * @coversDefaultClass \League\Period\Period
+ */
+class StringRepresentationTest extends TestCase
+{
+    public function testToString(): void
+    {
+        date_default_timezone_set('Africa/Nairobi');
+        $period = new Period('2014-05-01', '2014-05-08');
+        $res = (string) $period;
+        self::assertContains('2014-04-30T21:00:00', $res);
+        self::assertContains('2014-05-07T21:00:00', $res);
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $period = Period::fromMonth(2015, 4);
+        $json = json_encode($period);
+        self::assertInternalType('string', $json);
+        $res = json_decode($json);
+
+        self::assertEquals($period->getStartDate(), new DateTimeImmutable($res->startDate));
+        self::assertEquals($period->getEndDate(), new DateTimeImmutable($res->endDate));
+    }
+
+    public function testFormat(): void
+    {
+        date_default_timezone_set('Africa/Nairobi');
+        self::assertSame('[2015-04, 2015-05)', Period::fromMonth(2015, 4)->format('Y-m'));
+        self::assertSame(
+            '[2015-04-01 Africa/Nairobi, 2015-04-01 Africa/Nairobi)',
+            (new Period('2015-04-01', '2015-04-01'))->format('Y-m-d e')
+        );
+    }
+}

--- a/tests/PeriodComparisonTest.php
+++ b/tests/PeriodComparisonTest.php
@@ -192,13 +192,13 @@ class PeriodComparisonTest extends TestCase
                 false,
             ],
             'test abuts returns true with equal datepoints by if boundary is inclusif (1)' => [
-                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01'), Period::EXCLUDE_NONE),
-                new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-05-01'), Period::EXCLUDE_NONE),
+                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01'), Period::INCLUDE_ALL),
+                new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-05-01'), Period::INCLUDE_ALL),
                 false,
             ],
             'test abuts returns true with equal datepoints by if boundary is inclusif (2)' => [
-                new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-05-01'), Period::EXCLUDE_NONE),
-                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01'), Period::EXCLUDE_NONE),
+                new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-05-01'), Period::INCLUDE_ALL),
+                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01'), Period::INCLUDE_ALL),
                 false,
             ],
         ];
@@ -304,12 +304,12 @@ class PeriodComparisonTest extends TestCase
                 new Period(
                     new DateTimeImmutable('2014-03-01'),
                     new DateTimeImmutable('2014-06-01'),
-                    Period::EXCLUDE_NONE
+                    Period::INCLUDE_ALL
                 ),
                 new Period(
                     new DateTimeImmutable('2014-05-01'),
                     new DateTimeImmutable('2014-06-01'),
-                    Period::EXCLUDE_NONE
+                    Period::INCLUDE_ALL
                 ),
                 true,
             ],
@@ -369,8 +369,8 @@ class PeriodComparisonTest extends TestCase
                 true,
             ],
             'contains period same duration + boundary type OLOR vs OLOR' => [
-                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_NONE),
-                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_NONE),
+                Period::after('2012-01-08', '1 DAY', Period::INCLUDE_ALL),
+                Period::after('2012-01-08', '1 DAY', Period::INCLUDE_ALL),
                 true,
             ],
             'contains period same duration + boundary type CLOR vs CLOR' => [
@@ -380,21 +380,21 @@ class PeriodComparisonTest extends TestCase
             ],
             'contains period same duration + boundary type CLOR vs OLCR' => [
                 Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_START_INCLUDE_END),
-                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_END_INCLUDE_START),
+                Period::after('2012-01-08', '1 DAY', Period::INCLUDE_START_EXCLUDE_END),
                 false,
             ],
             'contains period same duration + boundary type OLCR vs CLOR' => [
-                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_END_INCLUDE_START),
+                Period::after('2012-01-08', '1 DAY', Period::INCLUDE_START_EXCLUDE_END),
                 Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_START_INCLUDE_END),
                 false,
             ],
             'contains period same duration + boundary type CLCR vs OLOR' => [
                 Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_ALL),
-                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_NONE),
+                Period::after('2012-01-08', '1 DAY', Period::INCLUDE_ALL),
                 false,
             ],
             'contains period same duration + boundary type OLOR vs CLCR' => [
-                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_NONE),
+                Period::after('2012-01-08', '1 DAY', Period::INCLUDE_ALL),
                 Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_ALL),
                 true,
             ],
@@ -423,13 +423,13 @@ class PeriodComparisonTest extends TestCase
                 false,
             ],
             [
-                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_NONE),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::INCLUDE_ALL),
                 new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16')),
                 true,
             ],
             [
                 new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_ALL),
-                new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16'), Period::EXCLUDE_NONE),
+                new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16'), Period::INCLUDE_ALL),
                 false,
             ],
         ];
@@ -463,7 +463,7 @@ class PeriodComparisonTest extends TestCase
             ],
             [
                 new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::EXCLUDE_ALL),
-                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::EXCLUDE_NONE),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::INCLUDE_ALL),
                 false,
             ],
         ];
@@ -525,7 +525,7 @@ class PeriodComparisonTest extends TestCase
                 false,
             ],
             'returns false with different range type' => [
-                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_NONE),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::INCLUDE_ALL),
                 new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_ALL),
                 false,
             ],

--- a/tests/PeriodComparisonTest.php
+++ b/tests/PeriodComparisonTest.php
@@ -1,0 +1,678 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use League\Period\Exception;
+use League\Period\Period;
+
+/**
+ * @coversDefaultClass \League\Period\Period
+ */
+class PeriodComparisonTest extends TestCase
+{
+    /**
+     * @dataProvider isBeforeProvider
+     *
+     * @param DateTimeInterface|Period $input
+     */
+    public function testIsBefore(Period $interval, $input, bool $expected): void
+    {
+        self::assertSame($expected, $interval->isBefore($input));
+    }
+
+    public function isBeforeProvider(): array
+    {
+        return [
+            'range exclude end date success' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => new DateTime('2015-01-01'),
+                'expected' => true,
+            ],
+            'range exclude end date fails' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => new DateTime('2010-01-01'),
+                'expected' => false,
+            ],
+            'range exclude end date abuts date fails' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => new DateTime('2012-01-01'),
+                'expected' => false,
+            ],
+            'range exclude start date success' => [
+                'interval' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => new DateTime('2015-01-01'),
+                'expected' => true,
+            ],
+            'range exclude start date fails' => [
+                'interval' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => new DateTime('2010-01-01'),
+                'expected' => false,
+            ],
+            'range exclude start date abuts date success' => [
+                'interval' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => new DateTime('2012-02-01'),
+                'expected' => false,
+            ],
+            'exclude end date is before interval' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => Period::fromMonth(2011, 1),
+                'expected' => false,
+            ],
+            'exclude end date is not before interval' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => Period::fromMonth(2013, 1),
+                'expected' => true,
+            ],
+            'exclude end date abuts interval start date' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => Period::fromMonth(2012, 2),
+                'expected' => true,
+            ],
+            'exclude start date is before interval' => [
+                'interval' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => Period::fromMonth(2012, 2),
+                'expected' => true,
+            ],
+            'exclude start date is not before interval' => [
+                'interval' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => Period::fromMonth(2012, 2),
+                'expected' => true,
+            ],
+            'exclude start date abuts interval start date' => [
+                'interval' => Period::after('2011-12-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'expected' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider isAfterProvider
+     *
+     * @param DateTimeInterface|Period $input
+     */
+    public function testIsAfer(Period $interval, $input, bool $expected): void
+    {
+        self::assertSame($expected, $interval->isAfter($input));
+    }
+
+
+    public function isAfterProvider(): array
+    {
+        return [
+            'range exclude end date success' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => new DateTime('2010-01-01'),
+                'expected' => true,
+            ],
+            'range exclude end date fails' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => new DateTime('2015-01-01'),
+                'expected' => false,
+            ],
+            'range exclude end date abuts date fails' => [
+                'interval' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => new DateTime('2012-02-01'),
+                'expected' => false,
+            ],
+            'range exclude start date success' => [
+                'interval' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => new DateTime('2012-01-01'),
+                'expected' => true,
+            ],
+            'exclude end date is before interval' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => Period::fromMonth(2011, 1),
+                'expected' => true,
+            ],
+            'exclude end date is not before interval' => [
+                'interval' => Period::fromMonth(2013, 1),
+                'input' => Period::fromMonth(2012, 1),
+                'expected' => true,
+            ],
+            'exclude end date abuts interval start date' => [
+                'interval' => Period::fromMonth(2012, 2),
+                'input' => Period::fromMonth(2012, 1),
+                'expected' => true,
+            ],
+            'exclude start date is before interval' => [
+                'interval' => Period::fromMonth(2012, 2),
+                'input' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'expected' => true,
+            ],
+            'exclude start date is not before interval' => [
+                'interval' => Period::fromMonth(2012, 2),
+                'input' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'expected' => true,
+            ],
+            'exclude start date abuts interval start date' => [
+                'interval' => Period::after('2012-01-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'input' => Period::after('2011-12-01', '1 MONTH', Period::EXCLUDE_START_INCLUDE_END),
+                'expected' => true,
+            ],
+            'exclude start date abuts interval start date -2-' => [
+                'interval' => Period::fromMonth(2012, 1),
+                'input' => Period::fromMonth(2012, 2),
+                'expected' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider abutsDataProvider
+     */
+    public function testAbuts(Period $interval, Period $arg, bool $expected): void
+    {
+        self::assertSame($expected, $interval->abuts($arg));
+    }
+
+    public function abutsDataProvider(): array
+    {
+        return [
+            'test abuts returns true with equal datepoints by defaut' => [
+                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01')),
+                new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-05-01')),
+                true,
+            ],
+            'test abuts returns fase without equal datepoints' => [
+                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01')),
+                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-03-01')),
+                false,
+            ],
+            'test abuts returns true with equal datepoints by if boundary is inclusif (1)' => [
+                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01'), Period::EXCLUDE_NONE),
+                new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-05-01'), Period::EXCLUDE_NONE),
+                false,
+            ],
+            'test abuts returns true with equal datepoints by if boundary is inclusif (2)' => [
+                new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-05-01'), Period::EXCLUDE_NONE),
+                new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01'), Period::EXCLUDE_NONE),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider overlapsDataProvider
+     */
+    public function testOverlaps(Period $interval, Period $arg, bool $expected): void
+    {
+        self::assertSame($expected, $interval->overlaps($arg));
+    }
+
+    public function overlapsDataProvider(): array
+    {
+        return [
+            'overlaps returns false with gapped intervals' => [
+                new Period(new DateTimeImmutable('2014-03-01'), new DateTimeImmutable('2014-04-01')),
+                new Period(new DateTimeImmutable('2013-04-01'), new DateTimeImmutable('2013-05-01')),
+                false,
+            ],
+            'overlaps returns false with abuts intervals' => [
+                new Period(new DateTimeImmutable('2014-03-01'), new DateTimeImmutable('2014-04-01')),
+                new Period(new DateTimeImmutable('2014-04-01'), new DateTimeImmutable('2014-05-01')),
+                false,
+            ],
+            'overlaps returns' => [
+                new Period(new DateTimeImmutable('2014-03-01'), new DateTimeImmutable('2014-04-01')),
+                new Period(new DateTimeImmutable('2014-03-15'), new DateTimeImmutable('2014-04-07')),
+                true,
+            ],
+            'overlaps returns with equals intervals' => [
+                new Period(new DateTimeImmutable('2014-03-01'), new DateTimeImmutable('2014-04-01')),
+                new Period(new DateTimeImmutable('2014-03-01'), new DateTimeImmutable('2014-04-01')),
+                true,
+            ],
+            'overlaps returns with contained intervals' => [
+                new Period(new DateTimeImmutable('2014-03-01'), new DateTimeImmutable('2014-04-01')),
+                new Period(new DateTimeImmutable('2014-03-13'), new DateTimeImmutable('2014-03-15')),
+                true,
+            ],
+            'overlaps returns with contained intervals backwards' => [
+                new Period(new DateTimeImmutable('2014-03-13'), new DateTimeImmutable('2014-03-15')),
+                new Period(new DateTimeImmutable('2014-03-01'), new DateTimeImmutable('2014-04-01')),
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider containsDataProvider
+     *
+     * @param DateTimeInterface|Period|string $arg
+     */
+    public function testContains(Period $interval, $arg, bool $expected): void
+    {
+        self::assertSame($expected, $interval->contains($arg));
+        if ($arg instanceof Period) {
+            self::assertSame($expected, $arg->isDuring($interval));
+        }
+    }
+
+    public function containsDataProvider(): array
+    {
+        return [
+            'contains returns true with a DateTimeInterface object' => [
+                new Period(new DateTimeImmutable('2014-03-10'), new DateTimeImmutable('2014-03-15')),
+                new DateTime('2014-03-12'),
+                true,
+            ],
+            'contains returns true with a Period object' => [
+                new Period(new DateTimeImmutable('2014-01-01'), new DateTimeImmutable('2014-06-01')),
+                new Period(new DateTimeImmutable('2014-01-01'), new DateTimeImmutable('2014-04-01')),
+                true,
+            ],
+            'contains returns true with a Period object (2)' => [
+                new Period(
+                    new DateTimeImmutable('2014-03-01'),
+                    new DateTimeImmutable('2014-06-01'),
+                    Period::EXCLUDE_START_INCLUDE_END
+                ),
+                new Period(
+                    new DateTimeImmutable('2014-05-01'),
+                    new DateTimeImmutable('2014-06-01'),
+                    Period::EXCLUDE_START_INCLUDE_END
+                ),
+                true,
+            ],
+            'contains returns true with a Period object (3)' => [
+                new Period(
+                    new DateTimeImmutable('2014-03-01'),
+                    new DateTimeImmutable('2014-06-01'),
+                    Period::EXCLUDE_ALL
+                ),
+                new Period(
+                    new DateTimeImmutable('2014-05-01'),
+                    new DateTimeImmutable('2014-06-01'),
+                    Period::EXCLUDE_ALL
+                ),
+                true,
+            ],
+            'contains returns true with a Period object (4)' => [
+                new Period(
+                    new DateTimeImmutable('2014-03-01'),
+                    new DateTimeImmutable('2014-06-01'),
+                    Period::EXCLUDE_NONE
+                ),
+                new Period(
+                    new DateTimeImmutable('2014-05-01'),
+                    new DateTimeImmutable('2014-06-01'),
+                    Period::EXCLUDE_NONE
+                ),
+                true,
+            ],
+            'contains returns false with a DateTimeInterface object' => [
+                new Period(new DateTimeImmutable('2014-03-13'), new DateTimeImmutable('2014-03-15')),
+                new DateTime('2015-03-12'),
+                false,
+            ],
+            'contains returns false with a DateTimeInterface object after the interval' => [
+                new Period(new DateTimeImmutable('2014-03-13'), new DateTimeImmutable('2014-03-15')),
+                '2012-03-12',
+                false,
+            ],
+            'contains returns false with a DateTimeInterface object before the interval' => [
+                new Period(new DateTimeImmutable('2014-03-13'), new DateTimeImmutable('2014-03-15')),
+                '2014-04-01',
+                false,
+            ],
+            'contains returns false with abuts interval' => [
+                new Period(new DateTimeImmutable('2014-01-01'), new DateTimeImmutable('2014-04-01')),
+                new Period(new DateTimeImmutable('2014-01-01'), new DateTimeImmutable('2014-06-01')),
+                false,
+            ],
+            'contains returns true with a Period objects sharing the same end date' => [
+                new Period(new DateTimeImmutable('2015-01-01'), new DateTimeImmutable('2016-01-01')),
+                new Period(new DateTimeImmutable('2015-12-01'), new DateTimeImmutable('2016-01-01')),
+                true,
+            ],
+            'contains returns false with O duration Period object' => [
+                new Period(new DateTimeImmutable('2012-03-12'), new DateTimeImmutable('2012-03-12')),
+                new DateTime('2012-03-12'),
+                false,
+            ],
+            'contains datetime edge case datetime equals start date' => [
+                Period::after('2012-01-08', '1 DAY'),
+                new DateTime('2012-01-08'),
+                true,
+            ],
+            'contains datetime edge case datetime equals end date' => [
+                Period::after('2012-01-08', '1 DAY'),
+                new DateTime('2012-01-09'),
+                false,
+            ],
+            'contains datetime edge case datetime equals start date OLCR interval' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_START_INCLUDE_END),
+                new DateTime('2012-01-08'),
+                false,
+            ],
+            'contains datetime edge case datetime equals end date CLCR interval' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_ALL),
+                new DateTime('2012-01-09'),
+                false,
+            ],
+            'contains period same duration + boundary type CLCR vs CLCR' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_ALL),
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_ALL),
+                true,
+            ],
+            'contains period same duration + boundary type OLOR vs OLOR' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_NONE),
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_NONE),
+                true,
+            ],
+            'contains period same duration + boundary type CLOR vs CLOR' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_START_INCLUDE_END),
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_START_INCLUDE_END),
+                true,
+            ],
+            'contains period same duration + boundary type CLOR vs OLCR' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_START_INCLUDE_END),
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_END_INCLUDE_START),
+                false,
+            ],
+            'contains period same duration + boundary type OLCR vs CLOR' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_END_INCLUDE_START),
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_START_INCLUDE_END),
+                false,
+            ],
+            'contains period same duration + boundary type CLCR vs OLOR' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_ALL),
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_NONE),
+                false,
+            ],
+            'contains period same duration + boundary type OLOR vs CLCR' => [
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_NONE),
+                Period::after('2012-01-08', '1 DAY', Period::EXCLUDE_ALL),
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider startsDataProvider
+     */
+    public function testStarts(Period $interval1, Period $interval2, bool $expected): void
+    {
+        self::assertSame($expected, $interval1->starts($interval2));
+    }
+
+    public function startsDataProvider(): array
+    {
+        return [
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15')),
+                new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16')),
+                true,
+            ],
+            [
+                new Period(new DateTime('2012-01-02'), new DateTime('2012-01-15')),
+                new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16')),
+                false,
+            ],
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_NONE),
+                new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16')),
+                true,
+            ],
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_ALL),
+                new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16'), Period::EXCLUDE_NONE),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider finishesDataProvider
+     */
+    public function testFinishes(Period $interval1, Period $interval2, bool $expected): void
+    {
+        self::assertSame($expected, $interval1->finishes($interval2));
+    }
+
+    public function finishesDataProvider(): array
+    {
+        return [
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16')),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16')),
+                true,
+            ],
+            [
+                new Period(new DateTime('2012-01-02'), new DateTime('2012-01-15')),
+                new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16')),
+                false,
+            ],
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16')),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::EXCLUDE_ALL),
+                true,
+            ],
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::EXCLUDE_ALL),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::EXCLUDE_NONE),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider durationCompareDataProvider
+     */
+    public function testDurationCompare(Period $interval1, Period $interval2, int $expected): void
+    {
+        self::assertSame($expected, $interval1->durationCompare($interval2));
+    }
+
+    public function durationCompareDataProvider(): array
+    {
+        return [
+            'duration less than' => [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15')),
+                new Period(new DateTime('2013-01-01'), new DateTime('2013-01-16')),
+                -1,
+            ],
+            'duration greater than' => [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15')),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-07')),
+                1,
+            ],
+            'duration equals with microsecond' => [
+                new Period(new DateTime('2012-01-01 00:00:00'), new DateTime('2012-01-03 00:00:00.123456')),
+                new Period(new DateTime('2012-02-02 00:00:00'), new DateTime('2012-02-04 00:00:00.123456')),
+                0,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider equalsDataProvider
+     */
+    public function testEquals(Period  $interval1, Period $interval2, bool $expected): void
+    {
+        self::assertSame($expected, $interval1->equals($interval2));
+    }
+
+    public function equalsDataProvider(): array
+    {
+        return [
+            'returns true' => [
+                new Period(new DateTime('2012-01-01 00:00:00'), new DateTime('2012-01-03 00:00:00')),
+                new Period(new DateTime('2012-01-01 00:00:00'), new DateTime('2012-01-03 00:00:00')),
+                true,
+            ],
+            'returns false' => [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15')),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-07')),
+                false,
+            ],
+            'returns false is argument order independent' => [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-07')),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15')),
+                false,
+            ],
+            'returns false with different range type' => [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_NONE),
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_ALL),
+                false,
+            ],
+        ];
+    }
+
+    public function testIntersect(): void
+    {
+        $orig = new Period(new DateTime('2011-12-01'), new DateTime('2012-04-01'));
+        $alt = new Period(new DateTime('2012-01-01'), new DateTime('2012-03-01'));
+        self::assertTrue($orig->intersect($alt)->equals(new Period('2012-01-01', '2012-03-01')));
+    }
+
+    public function testIntersectThrowsExceptionWithNoOverlappingTimeRange(): void
+    {
+        self::expectException(Exception::class);
+        $orig = new Period(new DateTime('2013-01-01'), new DateTime('2013-02-01'));
+        $alt = new Period(new DateTime('2012-01-01'), new DateTime('2012-03-01'));
+        $orig->intersect($alt);
+    }
+
+    public function testGap(): void
+    {
+        $orig = new Period(new DateTime('2011-12-01'), new DateTime('2012-02-01'));
+        $alt = new Period(new DateTime('2012-06-01'), new DateTime('2012-09-01'));
+        $gap = $orig->gap($alt);
+
+        self::assertEquals($orig->getEndDate(), $gap->getStartDate());
+        self::assertEquals($alt->getStartDate(), $gap->getEndDate());
+        self::assertTrue($gap->equals($alt->gap($orig)));
+    }
+
+    public function testGapThrowsExceptionWithOverlapsInterval(): void
+    {
+        self::expectException(Exception::class);
+        $orig = new Period(new DateTime('2011-12-01'), new DateTime('2012-02-01'));
+        $alt = new Period(new DateTime('2011-12-10'), new DateTime('2011-12-15'));
+        $orig->gap($alt);
+    }
+
+    public function testGapWithSameStartingInterval(): void
+    {
+        self::expectException(Exception::class);
+        $orig = new Period(new DateTime('2011-12-01'), new DateTime('2012-02-01'));
+        $alt = new Period(new DateTime('2011-12-01'), new DateTime('2011-12-15'));
+        $orig->gap($alt);
+    }
+
+    public function testGapWithSameEndingInterval(): void
+    {
+        self::expectException(Exception::class);
+        $orig = new Period(new DateTime('2011-12-01'), new DateTime('2012-02-01'));
+        $alt = new Period(new DateTime('2012-01-15'), new DateTime('2012-02-01'));
+        $orig->gap($alt);
+    }
+
+    public function testGapWithAdjacentInterval(): void
+    {
+        $orig = new Period(new DateTime('2011-12-01'), new DateTime('2012-02-01'));
+        $alt = new Period(new DateTime('2012-02-01'), new DateTime('2012-02-02'));
+        self::assertEquals(0, $orig->gap($alt)->getTimestampInterval());
+    }
+
+    public function testDiffThrowsException(): void
+    {
+        $interval1 = new Period(new DateTimeImmutable('2015-01-01'), new DateTimeImmutable('2016-01-01'));
+        $interval2 = new Period(new DateTimeImmutable('2013-01-01'), new DateTimeImmutable('2014-01-01'));
+
+        self::expectException(Exception::class);
+        $interval1->diff($interval2);
+    }
+
+    public function testDiffWithEqualsPeriod(): void
+    {
+        $period = new Period(new DateTimeImmutable('2013-01-01'), new DateTimeImmutable('2014-01-01'));
+        $alt = new Period(new DateTimeImmutable('2013-01-01'), new DateTimeImmutable('2014-01-01'));
+        [$diff1, $diff2] = $alt->diff($period);
+        self::assertNull($diff1);
+        self::assertNull($diff2);
+        self::assertEquals($alt->diff($period), $period->diff($alt));
+    }
+
+    public function testDiffWithPeriodSharingStartingDatepoints(): void
+    {
+        $period = new Period(new DateTimeImmutable('2013-01-01'), new DateTimeImmutable('2014-01-01'));
+        $alt = new Period(new DateTimeImmutable('2013-01-01'), new DateTimeImmutable('2013-04-01'));
+        [$diff1, $diff2] = $alt->diff($period);
+        self::assertInstanceOf(Period::class, $diff1);
+        self::assertNull($diff2);
+        self::assertEquals(new DateTimeImmutable('2013-04-01'), $diff1->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-01-01'), $diff1->getEndDate());
+        self::assertEquals($alt->diff($period), $period->diff($alt));
+    }
+
+    public function testDiffWithPeriodSharingEndingDatepoints(): void
+    {
+        $period = new Period(new DateTimeImmutable('2013-01-01'), new DateTimeImmutable('2014-01-01'));
+        $alt = new Period(new DateTimeImmutable('2013-10-01'), new DateTimeImmutable('2014-01-01'));
+        [$diff1, $diff2] = $alt->diff($period);
+        self::assertInstanceOf(Period::class, $diff1);
+        self::assertNull($diff2);
+        self::assertEquals(new DateTimeImmutable('2013-01-01'), $diff1->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2013-10-01'), $diff1->getEndDate());
+        self::assertEquals($alt->diff($period), $period->diff($alt));
+    }
+
+    public function testDiffWithOverlapsPeriod(): void
+    {
+        $period = new Period(new DateTimeImmutable('2013-01-01 10:00:00'), new DateTimeImmutable('2013-01-01 13:00:00'));
+        $alt = new Period(new DateTimeImmutable('2013-01-01 11:00:00'), new DateTimeImmutable('2013-01-01 14:00:00'));
+        [$diff1, $diff2] = $alt->diff($period);
+        self::assertInstanceOf(Period::class, $diff1);
+        self::assertInstanceOf(Period::class, $diff2);
+        self::assertSame(3600.0, $diff1->getTimestampInterval());
+        self::assertSame(3600.0, $diff2->getTimestampInterval());
+        self::assertEquals($alt->diff($period), $period->diff($alt));
+    }
+
+    /**
+     * @dataProvider durationCompareInnerMethodsDataProvider
+     */
+    public function testDurationCompareInnerMethods(Period $period1, Period $period2, string $method, bool $expected): void
+    {
+        self::assertSame($expected, $period1->$method($period2));
+    }
+
+    public function durationCompareInnerMethodsDataProvider(): array
+    {
+        return [
+            'testDurationLessThan' => [
+                new Period('2012-01-01', '2012-01-07'),
+                new Period('2013-01-01', '2013-02-01'),
+                'durationLessThan',
+                true,
+            ],
+            'testDurationGreaterThanReturnsTrue' => [
+                new Period('2012-01-01', '2012-02-01'),
+                new Period('2012-01-01', '2012-01-07'),
+                'durationGreaterThan',
+                true,
+            ],
+            'testdurationEqualsReturnsTrueWithMicroseconds' => [
+                new Period('2012-01-01 00:00:00', '2012-01-03 00:00:00'),
+                new Period('2012-02-02 00:00:00', '2012-02-04 00:00:00'),
+                'durationEquals',
+                true,
+            ],
+        ];
+    }
+}

--- a/tests/PeriodModificationTest.php
+++ b/tests/PeriodModificationTest.php
@@ -63,7 +63,7 @@ class PeriodModificationTest extends TestCase
         $altInterval = $interval->withBoundaryType(Period::EXCLUDE_ALL);
         self::assertEquals($interval->getDateInterval(), $interval->getDateInterval());
         self::assertNotEquals($interval->getBoundaryType(), $altInterval->getBoundaryType());
-        self::assertSame($interval, $interval->withBoundaryType(Period::EXCLUDE_END_INCLUDE_START));
+        self::assertSame($interval, $interval->withBoundaryType(Period::INCLUDE_START_EXCLUDE_END));
     }
 
     public function testWithBoundaryTypeFails(): void

--- a/tests/PeriodModificationTest.php
+++ b/tests/PeriodModificationTest.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period;
+
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
+use League\Period\Exception;
+use League\Period\Period;
+use TypeError;
+
+/**
+ * @coversDefaultClass \League\Period\Period
+ */
+class PeriodModificationTest extends TestCase
+{
+    public function testStartingOn(): void
+    {
+        $expected = new DateTime('2012-03-02');
+        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
+        $newInterval = $interval->startingOn($expected);
+        self::assertTrue($newInterval->getStartDate() == $expected);
+        self::assertEquals($interval->getStartDate(), new DateTimeImmutable('2014-01-13'));
+        self::assertSame($interval->startingOn($interval->getStartDate()), $interval);
+    }
+
+    public function testStartingOnFailedWithWrongStartDate(): void
+    {
+        self::expectException(Exception::class);
+        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
+        $interval->startingOn(new DateTime('2015-03-02'));
+    }
+
+    public function testEndingOn(): void
+    {
+        $expected  = new DateTime('2015-03-02');
+        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
+        $newInterval = $interval->endingOn($expected);
+        self::assertTrue($newInterval->getEndDate() == $expected);
+        self::assertEquals($interval->getEndDate(), new DateTimeImmutable('2014-01-20'));
+        self::assertSame($interval->endingOn($interval->getEndDate()), $interval);
+    }
+
+    public function testEndingOnFailedWithWrongEndDate(): void
+    {
+        self::expectException(Exception::class);
+        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
+        $interval->endingOn(new DateTime('2012-03-02'));
+    }
+
+    public function testWithBoundaryType(): void
+    {
+        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
+        $altInterval = $interval->withBoundaryType(Period::EXCLUDE_ALL);
+        self::assertEquals($interval->getDateInterval(), $interval->getDateInterval());
+        self::assertNotEquals($interval->getBoundaryType(), $altInterval->getBoundaryType());
+        self::assertSame($interval, $interval->withBoundaryType(Period::EXCLUDE_END_INCLUDE_START));
+    }
+
+    public function testWithBoundaryTypeFails(): void
+    {
+        self::expectException(Exception::class);
+        $interval = new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'));
+        $altInterval = $interval->withBoundaryType('foobar');
+    }
+
+    public function testExpand(): void
+    {
+        $interval = (new Period(new DateTime('2012-02-02'), new DateTime('2012-02-03')))->expand(new DateInterval('P1D'));
+        self::assertEquals(new DateTimeImmutable('2012-02-01'), $interval->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2012-02-04'), $interval->getEndDate());
+    }
+
+    public function testExpandRetunsSameInstance(): void
+    {
+        $interval = new Period(new DateTime('2012-02-02'), new DateTime('2012-02-03'));
+        self::assertSame($interval->expand(new DateInterval('PT0S')), $interval);
+    }
+
+    public function testShrink(): void
+    {
+        $dateInterval = new DateInterval('PT12H');
+        $dateInterval->invert = 1;
+        $interval = (new Period(new DateTime('2012-02-02'), new DateTime('2012-02-03')))->expand($dateInterval);
+        self::assertEquals(new DateTimeImmutable('2012-02-02 12:00:00'), $interval->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2012-02-02 12:00:00'), $interval->getEndDate());
+    }
+
+    public function testExpandThrowsException(): void
+    {
+        self::expectException(Exception::class);
+        $dateInterval = new DateInterval('P1D');
+        $dateInterval->invert = 1;
+        $interval = (new Period(new DateTime('2012-02-02'), new DateTime('2012-02-03')))->expand($dateInterval);
+    }
+
+    public function testMove(): void
+    {
+        $interval = new Period(new DateTime('2016-01-01 15:32:12'), new DateTime('2016-01-15 12:00:01'));
+        $moved = $interval->move(new DateInterval('P1D'));
+        self::assertFalse($interval->equals($moved));
+        self::assertTrue($interval->move(new DateInterval('PT0S'))->equals($interval));
+    }
+
+    public function testMoveSupportStringIntervals(): void
+    {
+        $interval = new Period(new DateTime('2016-01-01 15:32:12'), new DateTime('2016-01-15 12:00:01'));
+        $advanced = $interval->move(DateInterval::createFromDateString('1 DAY'));
+        $alt = new Period(new DateTime('2016-01-02 15:32:12'), new DateTime('2016-01-16 12:00:01'));
+        self::assertTrue($alt->equals($advanced));
+    }
+
+    public function testMoveWithInvertedInterval(): void
+    {
+        $orig = new Period(new DateTime('2016-01-01 15:32:12'), new DateTime('2016-01-15 12:00:01'));
+        $alt = new Period(new DateTime('2016-01-02 15:32:12'), new DateTime('2016-01-16 12:00:01'));
+        $duration = new DateInterval('P1D');
+        $duration->invert = 1;
+        self::assertTrue($orig->equals($alt->move($duration)));
+    }
+
+    public function testMoveWithInvertedStringInterval(): void
+    {
+        $orig = new Period(new DateTime('2016-01-01 15:32:12'), new DateTime('2016-01-15 12:00:01'));
+        $alt = new Period(new DateTime('2016-01-02 15:32:12'), new DateTime('2016-01-16 12:00:01'));
+        self::assertTrue($orig->equals($alt->move(DateInterval::createFromDateString('-1 DAY'))));
+    }
+
+    public function testWithDurationAfterStart(): void
+    {
+        $expected = new Period('2014-03-01', '2014-04-01');
+        $period = new Period('2014-03-01', '2014-03-15');
+        self::assertEquals($expected, $period->withDurationAfterStart('1 MONTH'));
+    }
+
+    public function testWithDurationAfterStartThrowsException(): void
+    {
+        self::expectException(Exception::class);
+        $period = new Period('2014-03-01', '2014-03-15');
+        $interval = new DateInterval('P1D');
+        $interval->invert = 1;
+        $period->withDurationAfterStart($interval);
+    }
+
+    public function testWithDurationBeforeEnd(): void
+    {
+        $expected = new Period('2014-02-01', '2014-03-01');
+        $period = new Period('2014-02-15', '2014-03-01');
+        self::assertEquals($expected, $period->withDurationBeforeEnd('1 MONTH'));
+    }
+
+    public function testWithDurationBeforeEndThrowsException(): void
+    {
+        self::expectException(Exception::class);
+        $period = new Period('2014-02-15', '2014-03-01');
+        $interval = new DateInterval('P1D');
+        $interval->invert = 1;
+        $period->withDurationBeforeEnd($interval);
+    }
+
+    public function testMerge(): void
+    {
+        $period = Period::fromMonth(2014, 3);
+        $altPeriod = Period::fromMonth(2014, 4);
+        $expected = Period::after('2014-03-01', '2 MONTHS');
+        self::assertEquals($expected, $period->merge($altPeriod));
+        self::assertEquals($expected, $altPeriod->merge($period));
+        self::assertEquals($expected, $expected->merge($period, $altPeriod));
+    }
+
+    public function testMergeThrowsException(): void
+    {
+        self::expectException(TypeError::class);
+        Period::fromMonth(2014, 3)->merge();
+    }
+
+    public function testMoveEndDate(): void
+    {
+        $orig = Period::after('2012-01-01', '2 MONTH');
+        $period = $orig->moveEndDate('-1 MONTH');
+        self::assertSame(1, $orig->durationCompare($period));
+        self::assertTrue($orig->durationGreaterThan($period));
+        self::assertEquals($orig->getStartDate(), $period->getStartDate());
+    }
+
+    public function testMoveEndDateThrowsException(): void
+    {
+        self::expectException(Exception::class);
+        Period::after('2012-01-01', '1 MONTH')->moveEndDate('-3 MONTHS');
+    }
+
+    public function testMoveStartDateBackward(): void
+    {
+        $orig = Period::fromMonth(2012, 1);
+        $period = $orig->moveStartDate('-1 MONTH');
+        self::assertSame(-1, $orig->durationCompare($period));
+        self::assertTrue($orig->durationLessThan($period));
+        self::assertEquals($orig->getEndDate(), $period->getEndDate());
+        self::assertNotEquals($orig->getStartDate(), $period->getStartDate());
+    }
+
+    public function testMoveStartDateForward(): void
+    {
+        $orig = Period::fromMonth(2012, 1);
+        $period = $orig->moveStartDate('2 WEEKS');
+        self::assertSame(1, $orig->durationCompare($period));
+        self::assertTrue($orig->durationGreaterThan($period));
+        self::assertEquals($orig->getEndDate(), $period->getEndDate());
+        self::assertNotEquals($orig->getStartDate(), $period->getStartDate());
+    }
+
+    public function testMoveStartDateThrowsException(): void
+    {
+        self::expectException(Exception::class);
+        Period::after('2012-01-01', '1 MONTH')->moveStartDate('3 MONTHS');
+    }
+}

--- a/tests/PeriodPropertiesTest.php
+++ b/tests/PeriodPropertiesTest.php
@@ -67,7 +67,7 @@ class PeriodPropertiesTest extends TestCase
         return [
             'left open right close' => [
                 'interval' => Period::fromDay(2012, 8, 12),
-                'rangeType' => Period::EXCLUDE_END_INCLUDE_START,
+                'rangeType' => Period::INCLUDE_START_EXCLUDE_END,
                 'startIncluded' => true,
                 'startExcluded' => false,
                 'endIncluded' => false,
@@ -82,8 +82,8 @@ class PeriodPropertiesTest extends TestCase
                 'endExcluded' => false,
             ],
             'left open right open' => [
-                'interval' => Period::after('2012-08-12', '1 DAY', Period::EXCLUDE_NONE),
-                'rangeType' => Period::EXCLUDE_NONE,
+                'interval' => Period::after('2012-08-12', '1 DAY', Period::INCLUDE_ALL),
+                'rangeType' => Period::INCLUDE_ALL,
                 'startIncluded' => true,
                 'startExcluded' => false,
                 'endIncluded' => true,

--- a/tests/PeriodPropertiesTest.php
+++ b/tests/PeriodPropertiesTest.php
@@ -1,0 +1,372 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period;
+
+use DateInterval;
+use DatePeriod;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
+use Generator;
+use League\Period\Exception;
+use League\Period\Period;
+use TypeError;
+
+/**
+ * @coversDefaultClass \League\Period\Period
+ */
+class PeriodPropertiesTest extends TestCase
+{
+    public function testConstructorThrowExceptionIfUnknownBounday(): void
+    {
+        self::expectException(Exception::class);
+        new Period(new DateTime('2014-01-13'), new DateTime('2014-01-20'), 'foobar');
+    }
+
+    public function testGetDateInterval(): void
+    {
+        $interval = new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-02-02'));
+        self::assertSame(1, $interval->getDateInterval()->days);
+    }
+
+    public function testGetTimestampInterval(): void
+    {
+        $interval = new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-02-02'));
+        self::assertSame(86400.0, $interval->getTimestampInterval());
+    }
+
+    /**
+     * @dataProvider providerGetRangType
+     */
+    public function testGetRangeType(
+        Period $interval,
+        string $rangeType,
+        bool $startIncluded,
+        bool $startExcluded,
+        bool $endIncluded,
+        bool $endExcluded
+    ): void {
+        self::assertSame($rangeType, $interval->getBoundaryType());
+        self::assertSame($startIncluded, $interval->isStartDateIncluded());
+        self::assertSame($startExcluded, $interval->isStartDateExcluded());
+        self::assertSame($endIncluded, $interval->isEndDateIncluded());
+        self::assertSame($endExcluded, $interval->isEndDateExcluded());
+    }
+
+    public function providerGetRangType(): array
+    {
+        return [
+            'left open right close' => [
+                'interval' => Period::fromDay(2012, 8, 12),
+                'rangeType' => Period::EXCLUDE_END_INCLUDE_START,
+                'startIncluded' => true,
+                'startExcluded' => false,
+                'endIncluded' => false,
+                'endExcluded' => true,
+            ],
+            'left close right open' => [
+                'interval' => Period::around('2012-08-12', '1 HOUR', Period::EXCLUDE_START_INCLUDE_END),
+                'rangeType' => Period::EXCLUDE_START_INCLUDE_END,
+                'startIncluded' => false,
+                'startExcluded' => true,
+                'endIncluded' => true,
+                'endExcluded' => false,
+            ],
+            'left open right open' => [
+                'interval' => Period::after('2012-08-12', '1 DAY', Period::EXCLUDE_NONE),
+                'rangeType' => Period::EXCLUDE_NONE,
+                'startIncluded' => true,
+                'startExcluded' => false,
+                'endIncluded' => true,
+                'endExcluded' => false,
+            ],
+            'left close right close' => [
+                'interval' => Period::before('2012-08-12', '1 WEEK', Period::EXCLUDE_ALL),
+                'rangeType' => Period::EXCLUDE_ALL,
+                'startIncluded' => false,
+                'startExcluded' => true,
+                'endIncluded' => false,
+                'endExcluded' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerGetDatePeriod
+     *
+     * @param DateInterval|int|string $interval
+     */
+    public function testGetDatePeriod($interval, int $option, int $count): void
+    {
+        $period = new Period(new DateTime('2012-01-12'), new DateTime('2012-01-13'));
+        $range = $period->getDatePeriod($interval, $option);
+        self::assertCount($count, iterator_to_array($range));
+    }
+
+    public function providerGetDatePeriod(): array
+    {
+        return [
+            'useDateInterval' => [new DateInterval('PT1H'), 0, 24],
+            'useString' => ['2 HOUR', 0, 12],
+            'useInt' => [9600, 0, 9],
+            'useFloat' => [14400.0, 0, 6],
+            'exclude start date useDateInterval' => [new DateInterval('PT1H'), DatePeriod::EXCLUDE_START_DATE, 23],
+            'exclude start date useString' => ['2 HOUR', DatePeriod::EXCLUDE_START_DATE, 11],
+            'exclude start date useInt' => [9600, DatePeriod::EXCLUDE_START_DATE, 8],
+            'exclude start date useFloat' => [14400.0, DatePeriod::EXCLUDE_START_DATE, 5],
+        ];
+    }
+
+    /**
+     * @dataProvider providerGetDatePeriodBackwards
+     *
+     * @param DateInterval|int|string $interval
+     */
+    public function testGetDatePeriodBackwards($interval, int $option, int $count): void
+    {
+        $period = new Period(new DateTime('2012-01-12'), new DateTime('2012-01-13'));
+        $range = $period->getDatePeriodBackwards($interval, $option);
+        self::assertInstanceOf(Generator::class, $range);
+        self::assertCount($count, iterator_to_array($range));
+    }
+
+    public function providerGetDatePeriodBackwards(): array
+    {
+        return [
+            'useDateInterval' => [new DateInterval('PT1H'), 0, 24],
+            'useString' => ['2 HOUR', 0, 12],
+            'useInt' => [9600, 0, 9],
+            'useFloat' => [14400.0, 0, 6],
+            'exclude start date useDateInterval' => [new DateInterval('PT1H'), DatePeriod::EXCLUDE_START_DATE, 23],
+            'exclude start date useString' => ['2 HOUR', DatePeriod::EXCLUDE_START_DATE, 11],
+            'exclude start date useInt' => [9600, DatePeriod::EXCLUDE_START_DATE, 8],
+            'exclude start date useFloat' => [14400.0, DatePeriod::EXCLUDE_START_DATE, 5],
+        ];
+    }
+    public function testToString(): void
+    {
+        date_default_timezone_set('Africa/Nairobi');
+        $period = new Period('2014-05-01', '2014-05-08');
+        $res = (string) $period;
+        self::assertContains('2014-04-30T21:00:00', $res);
+        self::assertContains('2014-05-07T21:00:00', $res);
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $period = Period::fromMonth(2015, 4);
+        $json = json_encode($period);
+        self::assertInternalType('string', $json);
+        $res = json_decode($json);
+
+        self::assertEquals($period->getStartDate(), new DateTimeImmutable($res->startDate));
+        self::assertEquals($period->getEndDate(), new DateTimeImmutable($res->endDate));
+    }
+
+    public function testFormat(): void
+    {
+        date_default_timezone_set('Africa/Nairobi');
+        self::assertSame('[2015-04, 2015-05)', Period::fromMonth(2015, 4)->format('Y-m'));
+        self::assertSame(
+            '[2015-04-01 Africa/Nairobi, 2015-04-01 Africa/Nairobi)',
+            (new Period('2015-04-01', '2015-04-01'))->format('Y-m-d e')
+        );
+    }
+
+    public function testConstructorThrowTypeError(): void
+    {
+        self::expectException(TypeError::class);
+        new Period(new DateTime(), []);
+    }
+
+    public function testSetState(): void
+    {
+        $period = new Period('2014-05-01', '2014-05-08');
+        $generatedPeriod = eval('return '.var_export($period, true).';');
+        self::assertTrue($generatedPeriod->equals($period));
+        self::assertEquals($generatedPeriod, $period);
+    }
+
+    public function testConstructor(): void
+    {
+        $period = new Period('2014-05-01', '2014-05-08');
+        self::assertEquals(new DateTimeImmutable('2014-05-01'), $period->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2014-05-08'), $period->getEndDate());
+    }
+
+    public function testConstructorWithMicroSecondsSucceed(): void
+    {
+        $period = new Period('2014-05-01 00:00:00', '2014-05-01 00:00:00');
+        self::assertEquals(new DateInterval('PT0S'), $period->getDateInterval());
+    }
+
+    public function testConstructorThrowException(): void
+    {
+        self::expectException(Exception::class);
+        new Period(
+            new DateTime('2014-05-01', new DateTimeZone('Europe/Paris')),
+            new DateTime('2014-05-01', new DateTimeZone('Africa/Nairobi'))
+        );
+    }
+
+    public function testConstructorWithDateTimeInterface(): void
+    {
+        $start = '2014-05-01';
+        $end = new DateTime('2014-05-08');
+        $period = new Period($start, $end);
+        self::assertSame($start, $period->getStartDate()->format('Y-m-d'));
+        self::assertEquals($end, $period->getEndDate());
+    }
+
+    public function testDateIntervalDiff(): void
+    {
+        $orig = Period::after('2012-01-01', '1 HOUR');
+        $alt = Period::after('2012-01-01', '2 HOUR');
+        self::assertSame(1, $orig->dateIntervalDiff($alt)->h);
+        self::assertSame(0, $orig->dateIntervalDiff($alt)->days);
+    }
+
+    public function testTimestampIntervalDiff(): void
+    {
+        $orig = Period::after('2012-01-01', '1 HOUR');
+        $alt = Period::after('2012-01-01', '2 HOUR');
+        self::assertEquals(-3600, $orig->timestampIntervalDiff($alt));
+    }
+
+    public function testDateIntervalDiffPositionIrrelevant(): void
+    {
+        $orig = Period::after('2012-01-01', '1 HOUR');
+        $alt = Period::after('2012-01-01', '2 HOUR');
+        $fromOrig = $orig->dateIntervalDiff($alt);
+        $fromOrig->invert = 1;
+        self::assertEquals($fromOrig, $alt->dateIntervalDiff($orig));
+    }
+
+    public function testSplit(): void
+    {
+        $period = new Period(new DateTime('2012-01-12'), new DateTime('2012-01-13'));
+        $range = $period->split(new DateInterval('PT1H'));
+        $i = 0;
+        foreach ($range as $innerPeriod) {
+            ++$i;
+        }
+        self::assertSame(24, $i);
+    }
+
+    public function testSplitMustRecreateParentObject(): void
+    {
+        $period = new Period(new DateTime('2012-01-12'), new DateTime('2012-01-13'));
+        $range = $period->split(new DateInterval('PT1H'));
+        $total = null;
+        foreach ($range as $part) {
+            if (null === $total) {
+                $total = $part;
+                continue;
+            }
+            $total = $total->endingOn($part->getEndDate());
+        }
+        self::assertInstanceOf(Period::class, $total);
+        self::assertTrue($total->equals($period));
+    }
+
+    public function testSplitWithLargeInterval(): void
+    {
+        $period = new Period(new DateTime('2012-01-12'), new DateTime('2012-01-13'));
+        $range = [];
+        foreach ($period->split(new DateInterval('P1Y')) as $innerPeriod) {
+            $range[] = $innerPeriod;
+        }
+        self::assertCount(1, $range);
+        self::assertTrue($range[0]->equals($period));
+    }
+
+    public function testSplitWithInconsistentInterval(): void
+    {
+        $last = null;
+        $period = new Period(new DateTime('2012-01-12'), new DateTime('2012-01-13'));
+
+        foreach ($period->split(new DateInterval('PT10H')) as $innerPeriod) {
+            $last = $innerPeriod;
+        }
+        self::assertNotNull($last);
+        self::assertSame(14400.0, $last->getTimestampInterval());
+    }
+
+    public function testSplitBackwards(): void
+    {
+        $period = new Period(new DateTime('2015-01-01'), new DateTime('2015-01-04'));
+        $range = $period->splitBackwards(new DateInterval('P1D'));
+        $list = [];
+        foreach ($range as $innerPeriod) {
+            $list[] = $innerPeriod;
+        }
+
+        $result = array_map(function (Period $range) {
+            return [
+                'start' => $range->getStartDate()->format('Y-m-d H:i:s'),
+                'end'   => $range->getEndDate()->format('Y-m-d H:i:s'),
+            ];
+        }, $list);
+
+        $expected = [
+            [
+                'start' => '2015-01-03 00:00:00',
+                'end'   => '2015-01-04 00:00:00',
+            ],
+            [
+                'start' => '2015-01-02 00:00:00',
+                'end'   => '2015-01-03 00:00:00',
+            ],
+            [
+                'start' => '2015-01-01 00:00:00',
+                'end'   => '2015-01-02 00:00:00',
+            ],
+        ];
+        self::assertSame($expected, $result);
+    }
+
+    public function testSplitBackwardsWithInconsistentInterval(): void
+    {
+        $period = new Period(new DateTime('2010-01-01'), new DateTime('2010-01-02'));
+        $last = null;
+        foreach ($period->splitBackwards(new DateInterval('PT10H')) as $innerPeriod) {
+            $last = $innerPeriod;
+        }
+
+        self::assertNotNull($last);
+        self::assertEquals(14400.0, $last->getTimestampInterval());
+    }
+
+    public function testSplitDaylightSavingsDayIntoHoursEndInterval(): void
+    {
+        date_default_timezone_set('Canada/Central');
+        $period = new Period(new DateTime('2018-11-04 00:00:00.000000'), new DateTime('2018-11-04 05:00:00.000000'));
+        $splits = $period->split(new DateInterval('PT30M'));
+        $i = 0;
+        foreach ($splits as $inner_period) {
+            ++$i;
+        }
+        self::assertSame(10, $i);
+    }
+
+    public function testSplitBackwardsDaylightSavingsDayIntoHoursStartInterval(): void
+    {
+        date_default_timezone_set('Canada/Central');
+        $period = new Period(new DateTime('2018-04-11 00:00:00.000000'), new DateTime('2018-04-11 05:00:00.000000'));
+        $splits = $period->splitBackwards(new DateInterval('PT30M'));
+        $i = 0;
+        foreach ($splits as $inner_period) {
+            ++$i;
+        }
+        self::assertSame(10, $i);
+    }
+}

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -12,15 +12,12 @@
 namespace LeagueTest\Period;
 
 use DateInterval;
-use DatePeriod;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
-use Generator;
 use League\Period\Exception;
 use League\Period\Period;
-use PHPUnit\Framework\TestCase;
 use TypeError;
 use function League\Period\instant;
 use function League\Period\interval_after;
@@ -28,86 +25,6 @@ use function League\Period\month;
 
 class PeriodTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    protected $timezone;
-
-    public function setUp(): void
-    {
-        $this->timezone = date_default_timezone_get();
-    }
-
-    public function tearDown(): void
-    {
-        date_default_timezone_set($this->timezone);
-    }
-
-    public function testGetDateInterval(): void
-    {
-        $interval = new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-02-02'));
-        self::assertSame(1, $interval->getDateInterval()->days);
-    }
-
-    public function testGetTimestampInterval(): void
-    {
-        $interval = new Period(new DateTimeImmutable('2012-02-01'), new DateTimeImmutable('2012-02-02'));
-        self::assertSame(86400.0, $interval->getTimestampInterval());
-    }
-
-    /**
-     * @dataProvider providerGetDatePeriod
-     *
-     * @param DateInterval|int|string $interval
-     */
-    public function testGetDatePeriod($interval, int $option, int $count): void
-    {
-        $period = new Period(new DateTime('2012-01-12'), new DateTime('2012-01-13'));
-        $range = $period->getDatePeriod($interval, $option);
-        self::assertCount($count, iterator_to_array($range));
-    }
-
-    public function providerGetDatePeriod(): array
-    {
-        return [
-            'useDateInterval' => [new DateInterval('PT1H'), 0, 24],
-            'useString' => ['2 HOUR', 0, 12],
-            'useInt' => [9600, 0, 9],
-            'useFloat' => [14400.0, 0, 6],
-            'exclude start date useDateInterval' => [new DateInterval('PT1H'), DatePeriod::EXCLUDE_START_DATE, 23],
-            'exclude start date useString' => ['2 HOUR', DatePeriod::EXCLUDE_START_DATE, 11],
-            'exclude start date useInt' => [9600, DatePeriod::EXCLUDE_START_DATE, 8],
-            'exclude start date useFloat' => [14400.0, DatePeriod::EXCLUDE_START_DATE, 5],
-        ];
-    }
-
-    /**
-     * @dataProvider providerGetDatePeriodBackwards
-     *
-     * @param DateInterval|int|string $interval
-     */
-    public function testGetDatePeriodBackwards($interval, int $option, int $count): void
-    {
-        $period = new Period(new DateTime('2012-01-12'), new DateTime('2012-01-13'));
-        $range = $period->getDatePeriodBackwards($interval, $option);
-        self::assertInstanceOf(Generator::class, $range);
-        self::assertCount($count, iterator_to_array($range));
-    }
-
-    public function providerGetDatePeriodBackwards(): array
-    {
-        return [
-            'useDateInterval' => [new DateInterval('PT1H'), 0, 24],
-            'useString' => ['2 HOUR', 0, 12],
-            'useInt' => [9600, 0, 9],
-            'useFloat' => [14400.0, 0, 6],
-            'exclude start date useDateInterval' => [new DateInterval('PT1H'), DatePeriod::EXCLUDE_START_DATE, 23],
-            'exclude start date useString' => ['2 HOUR', DatePeriod::EXCLUDE_START_DATE, 11],
-            'exclude start date useInt' => [9600, DatePeriod::EXCLUDE_START_DATE, 8],
-            'exclude start date useFloat' => [14400.0, DatePeriod::EXCLUDE_START_DATE, 5],
-        ];
-    }
-
     public function testIsBeforeDateTimeInterface(): void
     {
         $orig = new Period(new DateTimeImmutable('2012-01-01'), new DateTimeImmutable('2012-02-01'));

--- a/tests/SequenceTest.php
+++ b/tests/SequenceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Period (https://period.thephpleague.com).
+ * League.Period (https://period.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *
@@ -14,16 +14,11 @@ declare(strict_types=1);
 namespace LeagueTest\Period;
 
 use DateTimeImmutable;
+use League\Period\Datepoint;
 use League\Period\InvalidIndex;
 use League\Period\Period;
 use League\Period\Sequence;
-use PHPUnit\Framework\TestCase;
 use TypeError;
-use function League\Period\day;
-use function League\Period\interval_after;
-use function League\Period\interval_around;
-use function League\Period\iso_week;
-use function League\Period\month;
 
 /**
  * @coversDefaultClass League\Period\Sequence
@@ -36,7 +31,7 @@ final class SequenceTest extends TestCase
         self::assertTrue($sequence->isEmpty());
         self::assertCount(0, $sequence);
         self::assertNull($sequence->getBoundaries());
-        $sequence->push(day('2012-06-23'));
+        $sequence->push(Period::fromDay(2012, 6, 23));
         self::assertFalse($sequence->isEmpty());
         self::assertCount(1, $sequence);
         self::assertInstanceOf(Period::class, $sequence->getBoundaries());
@@ -44,7 +39,7 @@ final class SequenceTest extends TestCase
 
     public function testConstructor(): void
     {
-        $sequence = new Sequence(day('2012-06-23'), day('2012-06-23'));
+        $sequence = new Sequence(Period::fromDay(2012, 6, 23), Period::fromDay(2012, 6, 23));
         self::assertCount(2, $sequence);
         foreach ($sequence as $event) {
             self::assertInstanceOf(Period::class, $event);
@@ -53,8 +48,8 @@ final class SequenceTest extends TestCase
 
     public function testRemove(): void
     {
-        $event1 = day('2012-06-23');
-        $event2 = day('2012-06-23');
+        $event1 = Period::fromDay(2012, 6, 23);
+        $event2 = Period::fromDay(2012, 6, 23);
         $sequence = new Sequence($event1, $event2);
         self::assertSame($event1, $sequence->remove(0));
         self::assertTrue($sequence->contains($event1));
@@ -68,23 +63,23 @@ final class SequenceTest extends TestCase
 
     public function testGetter(): void
     {
-        $event1 = day('2012-06-23');
-        $event2 = day('2012-06-23');
-        $event3 = day('2012-06-25');
+        $event1 = Period::fromDay(2012, 6, 23);
+        $event2 = Period::fromDay(2012, 6, 23);
+        $event3 = Period::fromDay(2012, 6, 25);
         $sequence = new Sequence($event1, $event2);
         self::assertInstanceOf(Period::class, $sequence->getBoundaries());
         self::assertTrue($sequence->contains($event2));
         self::assertTrue($sequence->contains($event1));
-        self::assertTrue($sequence->contains(day('2012-06-23')));
+        self::assertTrue($sequence->contains(Period::fromDay(2012, 6, 23)));
         self::assertSame($event2, $sequence->get(1));
-        self::assertSame(0, $sequence->indexOf(day('2012-06-23')));
-        self::assertFalse($sequence->indexOf(day('2014-06-23')));
+        self::assertSame(0, $sequence->indexOf(Period::fromDay(2012, 6, 23)));
+        self::assertFalse($sequence->indexOf(Period::fromDay(2014, 6, 23)));
         $sequence->push($event3);
         self::assertCount(3, $sequence);
         self::assertSame(2, $sequence->indexOf($event3));
-        $sequence->unshift(day('2018-08-08'));
+        $sequence->unshift(Period::fromDay(2018, 8, 8));
         self::assertCount(4, $sequence);
-        self::assertTrue(day('2018-08-08')->equals($sequence->get(0)));
+        self::assertTrue(Period::fromDay(2018, 8, 8)->equals($sequence->get(0)));
         $sequence->clear();
         self::assertTrue($sequence->isEmpty());
         self::assertNull($sequence->getBoundaries());
@@ -98,40 +93,40 @@ final class SequenceTest extends TestCase
 
     public function testSetter(): void
     {
-        $sequence = new Sequence(day('2011-06-23'), day('2011-06-23'));
-        $sequence->set(0, day('2011-06-23'));
-        self::assertEquals(day('2011-06-23'), $sequence->get(0));
-        $sequence->set(1, day('2012-06-23'));
-        $sequence->set(0, day('2013-06-23'));
-        self::assertEquals(day('2012-06-23'), $sequence->get(1));
-        self::assertEquals(day('2013-06-23'), $sequence->get(0));
+        $sequence = new Sequence(Datepoint::create('2011-06-23')->getDay(), Datepoint::create('2011-06-23')->getDay());
+        $sequence->set(0, Datepoint::create('2011-06-23')->getDay());
+        self::assertEquals(Datepoint::create('2011-06-23')->getDay(), $sequence->get(0));
+        $sequence->set(1, Period::fromDay(2012, 6, 23));
+        $sequence->set(0, Datepoint::create('2013-06-23')->getDay());
+        self::assertEquals(Period::fromDay(2012, 6, 23), $sequence->get(1));
+        self::assertEquals(Datepoint::create('2013-06-23')->getDay(), $sequence->get(0));
         self::expectException(InvalidIndex::class);
-        $sequence->set(3, day('2013-06-23'));
+        $sequence->set(3, Datepoint::create('2013-06-23')->getDay());
     }
 
     public function testInsert(): void
     {
         $sequence = new Sequence();
-        $sequence->insert(0, day('2010-06-23'));
+        $sequence->insert(0, Datepoint::create('2010-06-23')->getDay());
         self::assertCount(1, $sequence);
-        $sequence->insert(0, day('2011-06-24'));
+        $sequence->insert(0, Datepoint::create('2011-06-24')->getDay());
         self::assertCount(2, $sequence);
-        $sequence->insert(2, day('2012-06-25'));
+        $sequence->insert(2, Datepoint::create('2012-06-25')->getDay());
         self::assertCount(3, $sequence);
-        self::assertTrue(day('2011-06-24')->equals($sequence->get(0)));
+        self::assertTrue(Datepoint::create('2011-06-24')->getDay()->equals($sequence->get(0)));
         self::expectException(InvalidIndex::class);
-        $sequence->insert(42, day('2011-06-23'));
+        $sequence->insert(42, Datepoint::create('2011-06-23')->getDay());
     }
 
     public function testJsonSerialize(): void
     {
-        $day = day('2010-06-23');
+        $day = Datepoint::create('2010-06-23')->getDay();
         self::assertSame('['.json_encode($day).']', json_encode(new Sequence($day)));
     }
 
     public function testFilterReturnsNewInstance(): void
     {
-        $sequence =new Sequence(day('2012-06-23'), day('2012-06-12'));
+        $sequence =new Sequence(Period::fromDay(2012, 6, 23), Datepoint::create('2012-06-12')->getDay());
 
         $filter = function (Period $period) {
             return $period->getStartDate() == new DateTimeImmutable('2012-06-23');
@@ -146,7 +141,7 @@ final class SequenceTest extends TestCase
 
     public function testFilterReturnsSameInstance(): void
     {
-        $sequence = new Sequence(day('2012-06-23'), day('2012-06-12'));
+        $sequence = new Sequence(Period::fromDay(2012, 6, 23), Datepoint::create('2012-06-12')->getDay());
 
         $filter = static function (Period $interval) {
             return true;
@@ -157,7 +152,7 @@ final class SequenceTest extends TestCase
 
     public function testSortedReturnsSameInstance(): void
     {
-        $sequence = new Sequence(day('2012-06-23'), day('2012-06-12'));
+        $sequence = new Sequence(Period::fromDay(2012, 6, 23), Datepoint::create('2012-06-12')->getDay());
         $sort = function (Period $event1, Period $event2) {
             return 0;
         };
@@ -167,7 +162,7 @@ final class SequenceTest extends TestCase
 
     public function testSortedReturnsNewInstance(): void
     {
-        $sequence = new Sequence(month(2012, 6), day('2012-06-23'), iso_week(2018, 3));
+        $sequence = new Sequence(Period::fromMonth(2012, 6), Period::fromDay(2012, 6, 23), Period::fromIsoWeek(2018, 3));
         $sort = static function (Period $event1, Period $event2) {
             return $event1->durationCompare($event2);
         };
@@ -177,8 +172,8 @@ final class SequenceTest extends TestCase
 
     public function testSort(): void
     {
-        $day1 = day('2012-06-23');
-        $day2 = day('2012-06-12');
+        $day1 = Period::fromDay(2012, 6, 23);
+        $day2 = Datepoint::create('2012-06-12')->getDay();
         $sequence = new Sequence($day1, $day2);
         self::assertSame([0 => $day1, 1 => $day2], $sequence->toArray());
         $compare = static function (Period $period1, Period $period2): int {
@@ -190,20 +185,28 @@ final class SequenceTest extends TestCase
 
     public function testSome(): void
     {
-        $interval = interval_after('2012-02-01 12:00:00', '1 HOUR');
+        $interval = Period::after('2012-02-01 12:00:00', '1 HOUR');
         $predicate = static function (Period $event) use ($interval) {
             return $interval->overlaps($event);
         };
-        $sequence = new Sequence(day('2012-02-01'), day('2013-02-01'), day('2014-02-01'));
+        $sequence = new Sequence(
+            Datepoint::create('2012-02-01')->getDay(),
+            Datepoint::create('2013-02-01')->getDay(),
+            Datepoint::create('2014-02-01')->getDay()
+        );
         self::assertTrue($sequence->some($predicate));
         self::assertFalse((new Sequence())->some($predicate));
     }
 
     public function testEvery(): void
     {
-        $sequence = new Sequence(day('2012-02-01'), day('2013-02-01'), day('2014-02-01'));
+        $sequence = new Sequence(
+            Datepoint::create('2012-02-01')->getDay(),
+            Datepoint::create('2013-02-01')->getDay(),
+            Datepoint::create('2014-02-01')->getDay()
+        );
 
-        $interval = interval_after('2012-01-01', '5 YEARS');
+        $interval = Period::after('2012-01-01', '5 YEARS');
         $predicate = function (Period $event) use ($interval) {
             return $interval->contains($event);
         };
@@ -276,9 +279,9 @@ final class SequenceTest extends TestCase
     public function testGaps1(): void
     {
         $sequence = new Sequence(
-            day('2018-11-29'),
-            interval_after('2018-11-29 + 7 DAYS', '1 DAY'),
-            interval_around('2018-11-29', '4 DAYS')
+            Datepoint::create('2018-11-29')->getDay(),
+            Period::after('2018-11-29 + 7 DAYS', '1 DAY'),
+            Period::around('2018-11-29', '4 DAYS')
         );
 
         $gaps = $sequence->getGaps();
@@ -297,12 +300,34 @@ final class SequenceTest extends TestCase
     public function testGaps2(): void
     {
         $sequence = new Sequence(
-            day('2018-11-29'),
-            interval_around('2018-11-29', '4 DAYS')
+            Datepoint::create('2018-11-29')->getDay(),
+            Period::around('2018-11-29', '4 DAYS')
         );
 
         $gaps = $sequence->getGaps();
         self::assertTrue($gaps->isEmpty());
+    }
+
+    public function testUnionReturnsSameInstance(): void
+    {
+        $sequence = new Sequence(Datepoint::create('2018-11-29')->getDay());
+        self::assertSame($sequence, $sequence->getUnions());
+    }
+
+    public function testUnion(): void
+    {
+        $sequence = new Sequence(
+            Datepoint::create('2018-11-29')->getYear(),
+            Datepoint::create('2018-11-29')->getMonth(),
+            Period::around('2016-06-01', '3 MONTHS')
+        );
+
+        $unions = $sequence->getUnions();
+        self::assertEquals($sequence->getBoundaries(), $unions->getBoundaries());
+        self::assertTrue($unions->getIntersections()->isEmpty());
+        self::assertEquals($sequence->getGaps(), $unions->getGaps());
+        self::assertTrue(Period::around('2016-06-01', '3 MONTHS')->equals($unions->get(0)));
+        self::assertTrue(Datepoint::create('2018-11-29')->getYear()->equals($unions->get(1)));
     }
 
     public function testMap(): void
@@ -324,7 +349,7 @@ final class SequenceTest extends TestCase
         self::assertSame('[2018-01-15, 2018-02-01)', $newSequence->get(0)->format('Y-m-d'));
     }
 
-    public function testMapReturnSameInstance(): void
+    public function testMapReturnsSameInstance(): void
     {
         $sequence = new Sequence(
             Period::fromMonth(2018, 1),

--- a/tests/SequenceTest.php
+++ b/tests/SequenceTest.php
@@ -311,7 +311,7 @@ final class SequenceTest extends TestCase
     public function testUnionReturnsSameInstance(): void
     {
         $sequence = new Sequence(Datepoint::create('2018-11-29')->getDay());
-        self::assertSame($sequence, $sequence->getUnions());
+        self::assertSame($sequence, $sequence->unions());
     }
 
     public function testUnion(): void
@@ -322,7 +322,7 @@ final class SequenceTest extends TestCase
             Period::around('2016-06-01', '3 MONTHS')
         );
 
-        $unions = $sequence->getUnions();
+        $unions = $sequence->unions();
         self::assertEquals($sequence->getBoundaries(), $unions->getBoundaries());
         self::assertTrue($unions->getIntersections()->isEmpty());
         self::assertEquals($sequence->getGaps(), $unions->getGaps());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LeagueTest\Period;
+
+use PHPUnit\Framework\TestCase as PHPUnitFrameworkTestCase;
+
+abstract class TestCase extends PHPUnitFrameworkTestCase
+{
+    /**
+     * @var string
+     */
+    protected $timezone;
+
+    public function setUp(): void
+    {
+        $this->timezone = date_default_timezone_get();
+    }
+
+    public function tearDown(): void
+    {
+        date_default_timezone_set($this->timezone);
+    }
+}


### PR DESCRIPTION
Boundary support is added to the package.

To avoid BC Break, by default the package constructors methods returns by default a left close right open interval