### PR TITLE
Improve relational methods names and scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ All Notable changes to `Period` will be documented in this file
     - `Period::bordersOnStart`
     - `Period::bordersOnEnd`
     - `Period::isDuring`
-    - `Period::startsBy`
-    - `Period::endsBy`
+    - `Period::isStartedBy`
+    - `Period::isEndedBy`
 - Added additional methods to the Sequence class
     - `Sequence::unions`
     - `Sequence::intersections`

--- a/docs/4.0/comparing.md
+++ b/docs/4.0/comparing.md
@@ -67,41 +67,51 @@ $period->isAfter('1982-06-02'); //returns true
 $period->isAfter($period->getStartDate()); //returns false
 ~~~
 
-### Period::startsBy
+### Period::isStartedBy
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::startsBy(Period $interval): bool
+public Period::isStartedBy(mixed $index): bool
 ~~~
 
-Tells whether both `Period` objects starts at the same datepoint.
+- Tells whether both `Period` objects starts at the same datepoint.
+- Tells whethter the submitted `DateTimeInterface` object is the interval included starting datepoint 
+
+#### Parameter
+
+The `$index` argument can be another `Period` object or a datepoint.
 
 #### Examples
 
 ~~~php
 $period = Period::fromMonth(2014, 3);
 $alt = Period::after('2014-03-01', '2 DAYS');
-$period->startsBy($alt); //return true
+$period->isStartedBy($alt); //return true
 //in this case $period->getStartDate() == $alt->getStartDate();
 ~~~
 
-### Period::endsBy
+### Period::isEndedBy
 
 <p class="message-info">Since <code>version 4.4</code></p>
 
 ~~~php
-public Period::endsBy(Period $interval): bool
+public Period::isEndedBy(mixed $index): bool
 ~~~
 
-Tells whether both `Period` objects ends at the same datepoint.
+- Tells whether both `Period` objects ends at the same datepoint.
+- Tells whether the submitted `DateTimeInterface` object is the interval included ending datepoint 
+
+#### Parameter
+
+The `$index` argument can be another `Period` object or a datepoint.
 
 #### Examples
 
 ~~~php
 $period = Period::fromMonth(2014, 3);
 $alt = Period::before('2014-04-01', '2 DAYS');
-$period->endsBy($alt); //return true
+$period->isEndedBy($alt); //return true
 //in this case $period->getEndDate() == $alt->getEndDate();
 ~~~
 

--- a/src/Period.php
+++ b/src/Period.php
@@ -486,11 +486,19 @@ final class Period implements JsonSerializable
      *
      *    [--------------------)
      *    [---------)
+     *
+     * @param mixed $index a datepoint or a Period object
      */
-    public function startsBy(self $interval): bool
+    public function isStartedBy($index): bool
     {
-        return $this->startDate == $interval->startDate
-            && $this->boundaryType[0] === $interval->boundaryType[0];
+        if ($index instanceof self) {
+            return $this->startDate == $index->startDate
+                && $this->boundaryType[0] === $index->boundaryType[0];
+        }
+
+        $index = self::getDatepoint($index);
+
+        return $index == $this->startDate && '[' === $this->boundaryType[0];
     }
 
     /**
@@ -504,11 +512,19 @@ final class Period implements JsonSerializable
      *
      *    [--------------------)
      *               [---------)
+     *
+     * @param mixed $index a datepoint or a Period object
      */
-    public function endsBy(self $interval): bool
+    public function isEndedBy($index): bool
     {
-        return $this->endDate == $interval->endDate
-            && $this->boundaryType[1] === $interval->boundaryType[1];
+        if ($index instanceof self) {
+            return $this->endDate == $index->endDate
+                && $this->boundaryType[1] === $index->boundaryType[1];
+        }
+
+        $index = self::getDatepoint($index);
+
+        return $index == $this->endDate && ']' === $this->boundaryType[1];
     }
 
     /**

--- a/tests/Period/IntervalRelationTest.php
+++ b/tests/Period/IntervalRelationTest.php
@@ -405,10 +405,11 @@ class IntervalRelationTest extends TestCase
 
     /**
      * @dataProvider startsDataProvider
+     * @param DateTimeInterface|Period $index
      */
-    public function testStarts(Period $interval1, Period $interval2, bool $expected): void
+    public function testStarts(Period $interval1, $index, bool $expected): void
     {
-        self::assertSame($expected, $interval1->startsBy($interval2));
+        self::assertSame($expected, $interval1->isStartedBy($index));
     }
 
     public function startsDataProvider(): array
@@ -434,15 +435,26 @@ class IntervalRelationTest extends TestCase
                 new Period(new DateTime('2012-01-01'), new DateTime('2013-01-16'), Period::INCLUDE_ALL),
                 false,
             ],
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::EXCLUDE_ALL),
+                new DateTime('2012-01-01'),
+                false,
+            ],
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-15'), Period::INCLUDE_START_EXCLUDE_END),
+                new DateTime('2012-01-01'),
+                true,
+            ],
         ];
     }
 
     /**
      * @dataProvider finishesDataProvider
+     * @param DateTimeInterface|Period $index
      */
-    public function testFinishes(Period $interval1, Period $interval2, bool $expected): void
+    public function testFinishes(Period $interval1, $index, bool $expected): void
     {
-        self::assertSame($expected, $interval1->endsBy($interval2));
+        self::assertSame($expected, $interval1->isEndedBy($index));
     }
 
     public function finishesDataProvider(): array
@@ -467,6 +479,16 @@ class IntervalRelationTest extends TestCase
                 new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::EXCLUDE_ALL),
                 new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::INCLUDE_ALL),
                 false,
+            ],
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::EXCLUDE_ALL),
+                new DateTime('2012-01-16'),
+                false,
+            ],
+            [
+                new Period(new DateTime('2012-01-01'), new DateTime('2012-01-16'), Period::INCLUDE_ALL),
+                new DateTime('2012-01-16'),
+                true,
             ],
         ];
     }


### PR DESCRIPTION
-  `Period::startsBy` -> `Period::isStartedBy`
- `Period::endsBy` -> `Period::isEndedBy`

Both methods now supports datepoints too.