### PR TITLE
adding Duration::withoutCarryOver mutation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All Notable changes to `Period` will be documented in this file
 
 ### Added
 
-- None
+- `Duration::withoutCarryOver`
 
 ### Fixed
 

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -76,3 +76,19 @@ echo $duration; // 'PT5M0.5S'
 ~~~
 
 As per the specification the smallest value (ie the second) can accept a decimal fraction.
+
+## Duration mutation method
+
+### Removing carry over
+
+~~~php
+public Duration::withoutCarryOver(void): self
+~~~
+
+Returns a new instance with recalculate time and date segments to remove carry over points. If the recalculate interval does not change the current object then it is returned as is, otherwise a new object is returned. In any cases the current object is not changed. The EPOCH time is used as the reference day to perform the calculation.
+
+~~~php
+$duration = Duration::create('33 days');
+echo $duration; // 'P33D'
+echo $duration->withoutCarryOver(); // 'P1M2D'
+~~~

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -82,13 +82,15 @@ As per the specification the smallest value (ie the second) can accept a decimal
 ### Removing carry over
 
 ~~~php
-public Duration::withoutCarryOver(void): self
+public Duration::withoutCarryOver($duration = '@0'): self
 ~~~
 
-Returns a new instance with recalculate time and date segments to remove carry over points. If the recalculate interval does not change the current object then it is returned as is, otherwise a new object is returned. In any cases the current object is not changed. The EPOCH time is used as the reference day to perform the calculation.
+Returns a new instance with recalculate time and date segments to remove carry over points according to a reference datepoint. If the recalculate interval does not change the current object then it is returned as is, otherwise a new object is returned. The reference datepoint can be any valid vaue accepted by the `Datepoint::create` named constructor.  
+The epoch time is used as the reference datepoint to perform the calculation if no datepoint is submitted.
 
 ~~~php
-$duration = Duration::create('33 days');
-echo $duration; // 'P33D'
-echo $duration->withoutCarryOver(); // 'P1M2D'
+$duration = Duration::create('29 days');
+echo $duration; // 'P29D'
+echo $duration->withoutCarryOver(); // 'P29D' Using the Epoch time reference
+echo $duration->withoutCarryOver('2020-02-01'); // 'P1M'
 ~~~

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -82,7 +82,7 @@ As per the specification the smallest value (ie the second) can accept a decimal
 ### Removing carry over
 
 ~~~php
-public Duration::withoutCarryOver($duration = '@0'): self
+public Duration::withoutCarryOver($duration = 0): self
 ~~~
 
 Returns a new instance with recalculate time and date segments to remove carry over points according to a reference datepoint. If the recalculate interval does not change the current object then it is returned as is, otherwise a new object is returned. The reference datepoint can be any valid vaue accepted by the `Datepoint::create` named constructor.  

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -9,9 +9,9 @@ title: The Sequence class
 
 A duration is the continuous portion of time between two datepoints expressed as a `DateInterval` object. The duration cannot be negative.
 
-The `Duration` class is introduced to ease duration manipulation. This class extends PHP's `DateInterval` class by adding a new named constructor.
+The `Duration` class is introduced to ease duration manipulation. This class extends PHP's `DateInterval` class.
 
-## Named constructor
+## Constructors
 
 ### Duration::create
 
@@ -32,7 +32,7 @@ Converts its single input into a `Duration` object or throws a `TypeError` other
 
 <p class="message-warning"><strong>WARNING:</strong> When the string is not parsable by <code>DateInterval::createFromDateString</code> a <code>DateInterval</code> object representing the <code>0</code> interval is returned as described in <a href="https://bugs.php.net/bug.php?id=50020">PHP bug #50020</a>.</p>
 
-### Examples
+#### Examples
 
 ~~~php
 use League\Period\Duration;
@@ -45,7 +45,7 @@ Duration::create(new Period('now', 'tomorrow'));
 // returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
 ~~~
 
-## Duration::__construct
+### Duration::__construct
 
 The constructor supports fraction on the smallest value.
 

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -171,9 +171,10 @@ final class Duration extends DateInterval
      * carry over points.
      *
      * @param mixed $datepoint a Reference datepoint
-     *                         by default will use the epoch time in UTC
+     *                         by default will use the epoch time
+     *                         accepts the same input as {@see Duration::create}
      */
-    public function withoutCarryOver($datepoint = '@0'): self
+    public function withoutCarryOver($datepoint = 0): self
     {
         if (!$datepoint instanceof DateTimeImmutable) {
             $datepoint = Datepoint::create($datepoint);

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -170,13 +170,16 @@ final class Duration extends DateInterval
      * an instance that contains the time and date segments recalculate to remove
      * carry over points.
      *
-     * The epoch time is used as the reference datepoint.
+     * @param mixed $datepoint a Reference datepoint
+     *                         by default will use the epoch time in UTC
      */
-    public function withoutCarryOver(): self
+    public function withoutCarryOver($datepoint = '@0'): self
     {
-        static $now;
-        $now = $now ?? new DateTimeImmutable('@0');
-        $duration = $now->diff($now->add($this));
+        if (!$datepoint instanceof DateTimeImmutable) {
+            $datepoint = Datepoint::create($datepoint);
+        }
+
+        $duration = $datepoint->diff($datepoint->add($this));
         if ($this->toString($duration) === $this->toString($this)) {
             return $this;
         }

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\Period;
 
 use DateInterval;
+use DateTimeImmutable;
 use function filter_var;
 use function preg_match;
 use function property_exists;
@@ -117,28 +118,36 @@ final class Duration extends DateInterval
      */
     public function __toString(): string
     {
+        return $this->toString($this);
+    }
+
+    /**
+     * Generates the ISO8601 interval string representation.
+     */
+    private function toString(DateInterval $interval): string
+    {
         $date = 'P';
-        foreach (['Y' => $this->y, 'M' => $this->m, 'D' => $this->d] as $key => $value) {
+        foreach (['Y' => $interval->y, 'M' => $interval->m, 'D' => $interval->d] as $key => $value) {
             if (0 !== $value) {
                 $date .= $value.$key;
             }
         }
 
         $time = 'T';
-        foreach (['H' => $this->h, 'M' => $this->i] as $key => $value) {
+        foreach (['H' => $interval->h, 'M' => $interval->i] as $key => $value) {
             if (0 !== $value) {
                 $time .= $value.$key;
             }
         }
 
-        if (0.0 !== $this->f) {
-            $time .= rtrim(sprintf('%f', $this->s + $this->f), '0').'S';
+        if (0.0 !== $interval->f) {
+            $time .= rtrim(sprintf('%f', $interval->s + $interval->f), '0').'S';
 
             return $date.$time;
         }
 
-        if (0 !== $this->s) {
-            $time .= $this->s.'S';
+        if (0 !== $interval->s) {
+            $time .= $interval->s.'S';
 
             return $date.$time;
         }
@@ -152,5 +161,26 @@ final class Duration extends DateInterval
         }
 
         return 'PT0S';
+    }
+
+    /**
+     * Returns a new instance with recalculate time and date segments to remove carry over points.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the time and date segments recalculate to remove
+     * carry over points.
+     *
+     * The epoch time is used as the reference datepoint.
+     */
+    public function withoutCarryOver(): self
+    {
+        static $now;
+        $now = $now ?? new DateTimeImmutable('@0');
+        $duration = $now->diff($now->add($this));
+        if ($this->toString($duration) === $this->toString($this)) {
+            return $this;
+        }
+
+        return self::create($duration);
     }
 }

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -83,4 +83,35 @@ class DurationTest extends TestCase
         self::assertSame('PT5M0.023658S', (string) $duration);
         self::assertSame(0.023658, $duration->f);
     }
+
+    /**
+     * @dataProvider withoutCarryOverDataProvider
+     */
+    public function testWithoutCarryOver(string $input, string $expected): void
+    {
+        $duration = new Duration($input);
+        self::assertSame($expected, (string) $duration->withoutCarryOver());
+    }
+
+    public function withoutCarryOverDataProvider(): iterable
+    {
+        return [
+            [
+                'input' => 'PT3H',
+                'expected' => 'PT3H',
+            ],
+            [
+                'input' => 'PT24H',
+                'expected' => 'P1D',
+            ],
+            [
+                'input' => 'P31D',
+                'expected' => 'P1M',
+            ],
+            [
+                'input' => 'P12M',
+                'expected' => 'P1Y',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Adding a way to normalize Duration output by removing the possible carry over. The method expect a datepoint as a reference date.