### PR TITLE
Sequence::getTotalTimeStampInterval

### DIFF
--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -222,6 +222,18 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     }
 
     /**
+     * Returns the sum of all instances duration as expressed in seconds.
+     */
+    public function getTotaTimestampInterval(): float
+    {
+        $func = function (int $carry, Period $interval): float {
+            return $carry + $interval->getTimestampInterval();
+        };
+
+        return $this->reduce($func, 0);
+    }
+
+    /**
      * Tells whether some intervals in the current instance satisfies the predicate.
      */
     public function some(callable $predicate): bool

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -224,7 +224,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     /**
      * Returns the sum of all instances durations as expressed in seconds.
      */
-    public function getTotaTimestampInterval(): float
+    public function getInnerTimestampInterval(): float
     {
         $func = function (int $carry, Period $interval): float {
             return $carry + $interval->getTimestampInterval();

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -222,7 +222,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     }
 
     /**
-     * Returns the sum of all instances duration as expressed in seconds.
+     * Returns the sum of all instances durations as expressed in seconds.
      */
     public function getTotaTimestampInterval(): float
     {

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -226,7 +226,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
      */
     public function getTotalTimestampInterval(): float
     {
-        $func = function (int $carry, Period $interval): float {
+        $func = function (float $carry, Period $interval): float {
             return $carry + $interval->getTimestampInterval();
         };
 

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -224,7 +224,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     /**
      * Returns the sum of all instances durations as expressed in seconds.
      */
-    public function getInnerTimestampInterval(): float
+    public function getTotalTimestampInterval(): float
     {
         $func = function (int $carry, Period $interval): float {
             return $carry + $interval->getTimestampInterval();


### PR DESCRIPTION
As asked in #78 I think that this method would be useful everytime you need to calculate the total amount of hours in a calendar.