### PR TITLE
Feature/adding method period substract

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -897,8 +897,6 @@ final class Period implements JsonSerializable
      *                [-----------)
      *          =
      * [--------------)
-     *
-     * @return Sequence
      */
     public function substract(self $interval): Sequence
     {

--- a/src/Period.php
+++ b/src/Period.php
@@ -909,7 +909,7 @@ final class Period implements JsonSerializable
         $diffArray = $this->diff($interval);
 
         $sequence = new Sequence();
-        foreach ($diffArray AS $diff) {
+        foreach ($diffArray as $diff) {
             if (null !== $diff && $this->overlaps($diff)) {
                 $sequence->push($diff);
             }

--- a/src/Period.php
+++ b/src/Period.php
@@ -888,6 +888,35 @@ final class Period implements JsonSerializable
     }
 
     /**
+     * Returns the difference set operation between two intervals and returns
+     * a Period objects or the null value when the result of the operation
+     * is empty.
+     *
+     * [--------------------)
+     *          -
+     *                [-----------)
+     *          =
+     * [--------------)
+     *
+     * @return null|Period
+     */
+    public function substract(self $interval): ?Period
+    {
+        if (!$this->overlaps($interval)) {
+            return $this;
+        }
+
+        $diffArray = $this->diff($interval);
+        foreach ($diffArray AS $diff) {
+            if ($diff && $this->overlaps($diff)) {
+                return $diff;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Returns the computed gap between two instances as a new instance.
      *
      * [--------------------)

--- a/src/Period.php
+++ b/src/Period.php
@@ -910,7 +910,7 @@ final class Period implements JsonSerializable
 
         $sequence = new Sequence();
         foreach ($diffArray AS $diff) {
-            if ($diff && $this->overlaps($diff)) {
+            if (null !== $diff && $this->overlaps($diff)) {
                 $sequence->push($diff);
             }
         }

--- a/src/Period.php
+++ b/src/Period.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace League\Period;
 
-use Sequence;
 use DateInterval;
 use DatePeriod;
 use DateTimeImmutable;

--- a/src/Period.php
+++ b/src/Period.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\Period;
 
+use Sequence;
 use DateInterval;
 use DatePeriod;
 use DateTimeImmutable;
@@ -888,9 +889,9 @@ final class Period implements JsonSerializable
     }
 
     /**
-     * Returns the difference set operation between two intervals and returns
-     * a Period objects or the null value when the result of the operation
-     * is empty.
+     * Returns the difference set operation between two intervals as a Sequence.
+     * The Sequence can contain from 0 to 2 Periods depending on the result of
+     * the operation.
      *
      * [--------------------)
      *          -
@@ -898,22 +899,24 @@ final class Period implements JsonSerializable
      *          =
      * [--------------)
      *
-     * @return null|Period
+     * @return Sequence
      */
-    public function substract(self $interval): ?Period
+    public function substract(self $interval): Sequence
     {
         if (!$this->overlaps($interval)) {
-            return $this;
+            return new Sequence($this);
         }
 
         $diffArray = $this->diff($interval);
+
+        $sequence = new Sequence();
         foreach ($diffArray AS $diff) {
             if ($diff && $this->overlaps($diff)) {
-                return $diff;
+                $sequence->push($diff);
             }
         }
 
-        return null;
+        return $sequence;
     }
 
     /**

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -566,6 +566,16 @@ class PeriodTest extends TestCase
         self::assertEquals(new DateTimeImmutable('2000-01-01 20:00:00'), $diff2->getEndDate());
     }
 
+    public function testSubstractWithSeparatePeriods(): void
+    {
+        $periodA = new Period(new DateTimeImmutable('2000-01-01 10:00:00'), new DateTimeImmutable('2000-01-01 14:00:00'));
+        $periodB = new Period(new DateTimeImmutable('2000-01-01 15:00:00'), new DateTimeImmutable('2000-01-01 20:00:00'));
+        $diff1 = $periodA->substract($periodB);
+        $diff2 = $periodB->substract($periodA);
+        self::assertNull($diff1);
+        self::assertNull($diff2);
+    }
+
     public function testToString(): void
     {
         date_default_timezone_set('Africa/Nairobi');

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -580,6 +580,20 @@ class PeriodTest extends TestCase
         self::assertTrue($diff2[0]->equals($periodB));
     }
 
+    public function testSubstractWithOnePeriodContainedInAnother(): void
+    {
+        $periodA = new Period(new DateTimeImmutable('2000-01-01 10:00:00'), new DateTimeImmutable('2000-01-01 20:00:00'));
+        $periodB = new Period(new DateTimeImmutable('2000-01-01 15:00:00'), new DateTimeImmutable('2000-01-01 16:00:00'));
+        $diff1 = $periodA->substract($periodB);
+        $diff2 = $periodB->substract($periodA);
+        self::assertCount(2, $diff1);
+        self::assertEquals(new DateTimeImmutable('2000-01-01 10:00:00'), $diff1[0]->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2000-01-01 15:00:00'), $diff1[0]->getEndDate());
+        self::assertEquals(new DateTimeImmutable('2000-01-01 16:00:00'), $diff1[1]->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2000-01-01 20:00:00'), $diff1[1]->getEndDate());
+        self::assertCount(0, $diff2);
+    }
+
     public function testToString(): void
     {
         date_default_timezone_set('Africa/Nairobi');

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -554,6 +554,18 @@ class PeriodTest extends TestCase
         self::assertEquals($alt->diff($period), $period->diff($alt));
     }
 
+    public function testSubstractWithOverlappingUnequalPeriods(): void
+    {
+        $periodA = new Period(new DateTimeImmutable('2000-01-01 10:00:00'), new DateTimeImmutable('2000-01-01 18:00:00'));
+        $periodB = new Period(new DateTimeImmutable('2000-01-01 14:00:00'), new DateTimeImmutable('2000-01-01 20:00:00'));
+        $diff1 = $periodA->substract($periodB);
+        $diff2 = $periodB->substract($periodA);
+        self::assertEquals(new DateTimeImmutable('2000-01-01 10:00:00'), $diff1->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2000-01-01 14:00:00'), $diff1->getEndDate());
+        self::assertEquals(new DateTimeImmutable('2000-01-01 18:00:00'), $diff2->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2000-01-01 20:00:00'), $diff2->getEndDate());
+    }
+
     public function testToString(): void
     {
         date_default_timezone_set('Africa/Nairobi');

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -560,10 +560,12 @@ class PeriodTest extends TestCase
         $periodB = new Period(new DateTimeImmutable('2000-01-01 14:00:00'), new DateTimeImmutable('2000-01-01 20:00:00'));
         $diff1 = $periodA->substract($periodB);
         $diff2 = $periodB->substract($periodA);
-        self::assertEquals(new DateTimeImmutable('2000-01-01 10:00:00'), $diff1->getStartDate());
-        self::assertEquals(new DateTimeImmutable('2000-01-01 14:00:00'), $diff1->getEndDate());
-        self::assertEquals(new DateTimeImmutable('2000-01-01 18:00:00'), $diff2->getStartDate());
-        self::assertEquals(new DateTimeImmutable('2000-01-01 20:00:00'), $diff2->getEndDate());
+        self::assertCount(1, $diff1);
+        self::assertEquals(new DateTimeImmutable('2000-01-01 10:00:00'), $diff1[0]->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2000-01-01 14:00:00'), $diff1[0]->getEndDate());
+        self::assertCount(1, $diff2);
+        self::assertEquals(new DateTimeImmutable('2000-01-01 18:00:00'), $diff2[0]->getStartDate());
+        self::assertEquals(new DateTimeImmutable('2000-01-01 20:00:00'), $diff2[0]->getEndDate());
     }
 
     public function testSubstractWithSeparatePeriods(): void
@@ -572,8 +574,10 @@ class PeriodTest extends TestCase
         $periodB = new Period(new DateTimeImmutable('2000-01-01 15:00:00'), new DateTimeImmutable('2000-01-01 20:00:00'));
         $diff1 = $periodA->substract($periodB);
         $diff2 = $periodB->substract($periodA);
-        self::assertTrue($diff1->equals($periodA));
-        self::assertTrue($diff2->equals($periodB));
+        self::assertCount(1, $diff1);
+        self::assertTrue($diff1[0]->equals($periodA));
+        self::assertCount(1, $diff2);
+        self::assertTrue($diff2[0]->equals($periodB));
     }
 
     public function testToString(): void

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -572,8 +572,8 @@ class PeriodTest extends TestCase
         $periodB = new Period(new DateTimeImmutable('2000-01-01 15:00:00'), new DateTimeImmutable('2000-01-01 20:00:00'));
         $diff1 = $periodA->substract($periodB);
         $diff2 = $periodB->substract($periodA);
-        self::assertNull($diff1);
-        self::assertNull($diff2);
+        self::assertTrue($diff1->equals($periodA));
+        self::assertTrue($diff2->equals($periodB));
     }
 
     public function testToString(): void


### PR DESCRIPTION
This method allows to substract 2 Period objects like the difference operation in sets.
Compared to Period::diff, this method operation is not commutative and returns only one possible result.
![image](https://user-images.githubusercontent.com/4517370/54434114-c2465380-472d-11e9-8047-7b81e382c075.png)
The method returns a `Sequence` that can contain from 0 to 2 `Period` objects.

This method will be required in a future `Sequence::substract` method
For major details check ticket #78 