### PR TITLE
Feature/adding method sequence substract

### DIFF
--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -108,6 +108,45 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     /**
      * Returns the intersections inside the instance.
      */
+    public function substract(Sequence $subIntervals): ?self
+    {
+        if (count($this) == 0) {
+            return new self();
+        } else if (count($subIntervals) == 0) {
+            return $this;
+        } else if (count($this) == 1 && count($subIntervals) == 1) {
+            return $this->get(0)->substract($subIntervals->get(0));
+        } else if (count($this) > 1) {
+            $diffSequences = [];
+            foreach ($this->intervals as $intervalA) {
+                $tmpSequence = new self($intervalA);
+                $diffSequences[] = $tmpSequence->substract($subIntervals);
+            }
+
+            $newSequence = new self();
+            foreach ($diffSequences AS $diffSequence) {
+                foreach ($diffSequence AS $sequence) {
+                    $newSequence->push($sequence);
+                }
+            }
+
+            return $newSequence;
+        } else if (count($this) == 1 && count($subIntervals) > 1) {
+            $newSequence = new self($this->get(0));
+            foreach ($subIntervals as $subInterval) {
+                $tmpSequence = new self($subInterval);
+                $newSequence = $newSequence->substract($tmpSequence);
+            }
+
+            return $newSequence;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the intersections inside the instance.
+     */
     public function intersections(): self
     {
         $sequence = new self();

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -124,8 +124,8 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
             }
 
             $newSequence = new self();
-            foreach ($diffSequences AS $diffSequence) {
-                foreach ($diffSequence AS $sequence) {
+            foreach ($diffSequences as $diffSequence) {
+                foreach ($diffSequence as $sequence) {
                     $newSequence->push($sequence);
                 }
             }

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -108,7 +108,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     /**
      * Returns the intersections inside the instance.
      */
-    public function substract(Sequence $subIntervals): ?self
+    public function substract(Sequence $subIntervals): self
     {
         if (count($this) == 0) {
             return new self();
@@ -141,7 +141,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
             return $newSequence;
         }
 
-        return null;
+        return new self();
     }
 
     /**

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -112,11 +112,11 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
     {
         if (count($this) == 0) {
             return new self();
-        } else if (count($subIntervals) == 0) {
+        } elseif (count($subIntervals) == 0) {
             return $this;
-        } else if (count($this) == 1 && count($subIntervals) == 1) {
+        } elseif (count($this) == 1 && count($subIntervals) == 1) {
             return $this->get(0)->substract($subIntervals->get(0));
-        } else if (count($this) > 1) {
+        } elseif (count($this) > 1) {
             $diffSequences = [];
             foreach ($this->intervals as $intervalA) {
                 $tmpSequence = new self($intervalA);
@@ -131,7 +131,7 @@ final class Sequence implements ArrayAccess, Countable, IteratorAggregate, JsonS
             }
 
             return $newSequence;
-        } else if (count($this) == 1 && count($subIntervals) > 1) {
+        } elseif (count($this) == 1 && count($subIntervals) > 1) {
             $newSequence = new self($this->get(0));
             foreach ($subIntervals as $subInterval) {
                 $tmpSequence = new self($subInterval);

--- a/tests/SequenceTest.php
+++ b/tests/SequenceTest.php
@@ -279,8 +279,8 @@ final class SequenceTest extends TestCase
 
         $diff1 = $sequenceA->substract($sequenceB);
         self::assertCount(2, $diff1);
-        self::assertSame('[2000-01-01, 2000-01-10)', $diff->get(0)->format('Y-m-d'));
-        self::assertSame('[2000-01-12, 2000-01-20)', $diff->get(1)->format('Y-m-d'));
+        self::assertSame('[2000-01-01, 2000-01-10)', $diff1->get(0)->format('Y-m-d'));
+        self::assertSame('[2000-01-12, 2000-01-20)', $diff1->get(1)->format('Y-m-d'));
 
         $diff2 = $sequenceB->substract($sequenceA);
         self::assertCount(0, $diff2);

--- a/tests/SequenceTest.php
+++ b/tests/SequenceTest.php
@@ -217,6 +217,76 @@ final class SequenceTest extends TestCase
     }
 
     /**
+     * Substract test 1.
+     *
+     *  [-------------)      [------------)
+     *                   -
+     *       [--)         [---------------------)
+     *                   =
+     *  [----)   [----)
+     */
+    public function testSubstract1(): void
+    {
+        $sequenceA = new Sequence(
+            new Period('2000-01-01', '2000-01-10'),
+            new Period('2000-01-12', '2000-01-20')
+        );
+        $sequenceB = new Sequence(
+            new Period('2000-01-05', '2000-01-08'),
+            new Period('2000-01-11', '2000-01-25')
+        );
+        $diff = $sequenceA->substract($sequenceB);
+
+        self::assertCount(2, $diff);
+        self::assertSame('[2000-01-01, 2000-01-05)', $diff->get(0)->format('Y-m-d'));
+        self::assertSame('[2000-01-08, 2000-01-10)', $diff->get(1)->format('Y-m-d'));
+    }
+
+    /**
+     * Substract test 2.
+     *
+     *  [------)      [------)      [------)
+     *                   -
+     *  [------------------------------------------)
+     *                   =
+     *  ()
+     */
+    public function testSubstract2(): void
+    {
+        $sequenceA = new Sequence(
+            new Period('2000-01-01', '2000-01-05'),
+            new Period('2000-01-10', '2000-01-15'),
+            new Period('2000-01-20', '2000-01-25')
+        );
+        $sequenceB = new Sequence(
+            new Period('2000-01-01', '2000-01-30')
+        );
+        $diff = $sequenceA->substract($sequenceB);
+
+        self::assertCount(0, $diff);
+    }
+
+    /**
+     * Substract test 3.
+     */
+    public function testSubstract3(): void
+    {
+        $sequenceA = new Sequence(
+            new Period('2000-01-01', '2000-01-10'),
+            new Period('2000-01-12', '2000-01-20')
+        );
+        $sequenceB = new Sequence();
+
+        $diff1 = $sequenceA->substract($sequenceB);
+        self::assertCount(2, $diff1);
+        self::assertSame('[2000-01-01, 2000-01-10)', $diff->get(0)->format('Y-m-d'));
+        self::assertSame('[2000-01-12, 2000-01-20)', $diff->get(1)->format('Y-m-d'));
+
+        $diff2 = $sequenceB->substract($sequenceA);
+        self::assertCount(0, $diff2);
+    }
+
+    /**
      * Intersections test 1.
      *
      *               [------------)


### PR DESCRIPTION
Adding the new method Sequence::substract.
This function can be really useful in calendar operations when you want to substract a subset of intervals from another bigger interval.
Here is an example:

![immagine](https://user-images.githubusercontent.com/4517370/54542273-c8da0280-499b-11e9-8ef9-31fd7280ce4f.png)

This feature should close issue #78 
