### PR TITLE
Added immutability/purity markers, refined psalm types, tested types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,4 @@
 /CHANGELOG.md       export-ignore
 /CONDUCT.md         export-ignore
 /phpunit.xml        export-ignore
+/psalm.xml          export-ignore

--- a/composer.json
+++ b/composer.json
@@ -49,10 +49,11 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
         "infection/infection": "^0.13",
-        "phpunit/phpunit" : "^8.0",
         "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
         "phpstan/phpstan-strict-rules": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12"
+        "phpunit/phpunit": "^8.0",
+        "vimeo/psalm": "^3.10"
     },
     "autoload": {
         "psr-4": {
@@ -62,7 +63,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "LeagueTest\\Period\\": "tests"
+            "LeagueTest\\Period\\StaticAnalysis\\": "tests/static-analysis/",
+            "LeagueTest\\Period\\": "tests/"
         }
     },
     "scripts": {
@@ -73,12 +75,14 @@
             "@phpstan-src",
             "@phpstan-tests"
         ],
+        "psalm": "psalm --show-info=false",
         "phpunit": "phpunit --coverage-text",
         "infection-linux": "infection -j$(nproc) --coverage=build --ignore-msi-with-no-mutations --min-covered-msi=80 --ansi",
         "infection-osx": "infection -j$(sysctl -n hw.ncpu) --coverage=build --ignore-msi-with-no-mutations --min-covered-msi=80 --ansi",
         "test": [
             "@phpcs",
             "@phpstan",
+            "@psalm",
             "@phpunit"
         ],
         "test-linux": [

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    errorLevel="1"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="tests/static-analysis" />
+    </projectFiles>
+</psalm>

--- a/src/Datepoint.php
+++ b/src/Datepoint.php
@@ -25,6 +25,8 @@ use const FILTER_VALIDATE_INT;
 /**
  * League Period Datepoint.
  *
+ * @psalm-immutable
+ *
  * @package League.period
  * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @since   4.2.0
@@ -42,6 +44,9 @@ final class Datepoint extends DateTimeImmutable
      * </ul>
      *
      * @param mixed $datepoint a position in time
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function create($datepoint): self
     {
@@ -64,6 +69,9 @@ final class Datepoint extends DateTimeImmutable
      * @param DateTimeZone $timezone
      *
      * @return static|false
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function createFromFormat($format, $datetime, $timezone = null)
     {
@@ -81,6 +89,9 @@ final class Datepoint extends DateTimeImmutable
      * @param DateTime $datetime
      *
      * @return static
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function createFromMutable($datetime): self
     {

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -30,6 +30,8 @@ use const FILTER_VALIDATE_INT;
 /**
  * League Period Duration.
  *
+ * @psalm-immutable
+ *
  * @package League.period
  * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @since   4.2.0
@@ -50,6 +52,9 @@ final class Duration extends DateInterval
      * New instance.
      *
      * Returns a new instance from an Interval specification
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public function __construct(string $interval_spec)
     {
@@ -82,6 +87,9 @@ final class Duration extends DateInterval
      * @param mixed $duration a continuous portion of time
      *
      * @throws TypeError if the duration type is not a supported
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function create($duration): self
     {
@@ -151,6 +159,9 @@ final class Duration extends DateInterval
      * @param mixed $duration a date with relative parts
      *
      * @return static|false
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function createFromDateString($duration): self
     {

--- a/src/Period.php
+++ b/src/Period.php
@@ -27,6 +27,8 @@ use function sprintf;
 /**
  * A immutable value object class to manipulate Time interval.
  *
+ * @psalm-immutable
+ *
  * @package League.period
  * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @since   1.0.0
@@ -134,8 +136,11 @@ final class Period implements JsonSerializable
 
     /**
      * @inheritDoc
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
-    public static function __set_state(array $interval)
+    public static function __set_state(array $interval): self
     {
         return new self($interval['startDate'], $interval['endDate'], $interval['boundaryType'] ?? self::INCLUDE_START_EXCLUDE_END);
     }
@@ -145,6 +150,9 @@ final class Period implements JsonSerializable
      *
      * @param mixed $startDate the starting datepoint
      * @param mixed $duration  a Duration
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function after($startDate, $duration, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -158,6 +166,9 @@ final class Period implements JsonSerializable
      *
      * @param mixed $endDate  the ending datepoint
      * @param mixed $duration a Duration
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function before($endDate, $duration, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -172,6 +183,9 @@ final class Period implements JsonSerializable
      *
      * @param mixed $datepoint a Datepoint
      * @param mixed $duration  a Duration
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function around($datepoint, $duration, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -183,6 +197,9 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance from a DatePeriod.
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromDatePeriod(DatePeriod $datePeriod, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -191,6 +208,9 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance for a specific year.
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromYear(int $year, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -201,6 +221,9 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance for a specific ISO year.
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromIsoYear(int $year, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -213,6 +236,9 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance for a specific year and semester.
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromSemester(int $year, int $semester = 1, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -224,6 +250,9 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance for a specific year and quarter.
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromQuarter(int $year, int $quarter = 1, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -235,6 +264,9 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance for a specific year and month.
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromMonth(int $year, int $month = 1, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -245,6 +277,9 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance for a specific ISO8601 week.
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromIsoWeek(int $year, int $week = 1, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -255,6 +290,9 @@ final class Period implements JsonSerializable
 
     /**
      * Creates new instance for a specific year, month and day.
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromDay(int $year, int $month = 1, int $day = 1, string $boundaryType = self::INCLUDE_START_EXCLUDE_END): self
     {
@@ -269,6 +307,8 @@ final class Period implements JsonSerializable
 
     /**
      * Returns the starting datepoint.
+     *
+     * @psalm-return non-empty-string
      */
     public function getStartDate(): DateTimeImmutable
     {

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -34,6 +34,8 @@ use const ARRAY_FILTER_USE_BOTH;
 /**
  * A class to manipulate interval collection.
  *
+ * @psalm-immutable
+ *
  * @package League.period
  * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @since   4.1.0

--- a/tests/static-analysis/DatepointIsImmutable.php
+++ b/tests/static-analysis/DatepointIsImmutable.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace LeagueTest\Period\StaticAnalysis;
+
+use DateTime;
+use League\Period\Datepoint;
+use League\Period\Period;
+
+/**
+ * This is a static analysis fixture to verify that the API signature
+ * of a period allows for pure operations. Almost all methods will seem to be
+ * redundant or trivial: that's normal, we're just verifying the
+ * transitivity of immutable type signatures.
+ *
+ * Please note that this does not guarantee that the internals of the period
+ * library are pure/safe, but just that the declared API to the outside world
+ * is seen as immutable.
+ */
+final class DatepointIsImmutable
+{
+    /**
+     * @return Datepoint[]|bool[]
+     *
+     * @psalm-pure
+     */
+    public static function pureStaticDatepointApi(string $datepoint): array
+    {
+        return [
+            Datepoint::create($datepoint),
+            Datepoint::createFromFormat('Y-m-d', $datepoint),
+        ];
+    }
+
+    /** @psalm-pure */
+    public static function pureDatePointFromMutable(DateTime $dateTime): Datepoint
+    {
+        return Datepoint::createFromMutable($dateTime);
+    }
+
+    /**
+     * @return Period[]
+     *
+     * @psalm-pure
+     */
+    public static function pureIntervalConstructors(Datepoint $a): array
+    {
+        return [
+            $a->getSecond(),
+            $a->getMinute(),
+            $a->getHour(),
+            $a->getDay(),
+            $a->getIsoWeek(),
+            $a->getMonth(),
+            $a->getQuarter(),
+            $a->getSemester(),
+            $a->getYear(),
+            $a->getIsoYear(),
+
+        ];
+    }
+
+    /**
+     * @return bool[]
+     *
+     * @psalm-pure
+     */
+    public static function pureRelationMethods(Datepoint $a, Period $b): array
+    {
+        return [
+            $a->isBefore($b),
+            $a->bordersOnStart($b),
+            $a->isStarting($b),
+            $a->isDuring($b),
+            $a->isEnding($b),
+            $a->bordersOnEnd($b),
+            $a->abuts($b),
+            $a->isAfter($b),
+        ];
+    }
+}

--- a/tests/static-analysis/DurationIsImmutable.php
+++ b/tests/static-analysis/DurationIsImmutable.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace LeagueTest\Period\StaticAnalysis;
+
+use DateTimeImmutable;
+use League\Period\Duration;
+
+/**
+ * This is a static analysis fixture to verify that the API signature
+ * of a period allows for pure operations. Almost all methods will seem to be
+ * redundant or trivial: that's normal, we're just verifying the
+ * transitivity of immutable type signatures.
+ *
+ * Please note that this does not guarantee that the internals of the period
+ * library are pure/safe, but just that the declared API to the outside world
+ * is seen as immutable.
+ */
+final class DurationIsImmutable
+{
+    /** @psalm-pure */
+    public static function pureConstructor(): Duration
+    {
+        return new Duration('1 year');
+    }
+
+    /**
+     * @return Duration[]|bool[]
+     *
+     * @psalm-pure
+     */
+    public static function pureStaticDurationApi(string $duration): array
+    {
+        return [
+            Duration::create($duration),
+            Duration::createFromDateString($duration),
+        ];
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-suppress DeprecatedMethod
+     */
+    public static function pureStringRepresentation(Duration $a): string
+    {
+        return $a->__toString();
+    }
+
+    /**
+     * @return Duration[]|bool[]
+     *
+     * @psalm-pure
+     * @psalm-suppress DeprecatedMethod
+     */
+    public static function pureAdjustment(Duration $a, DateTimeImmutable $reference_date): array
+    {
+        return [
+            $a->withoutCarryOver($reference_date),
+            $a->adjustedTo($reference_date),
+        ];
+    }
+}

--- a/tests/static-analysis/PeriodIsImmutable.php
+++ b/tests/static-analysis/PeriodIsImmutable.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace LeagueTest\Period\StaticAnalysis;
+
+use DateInterval;
+use DatePeriod;
+use DateTimeImmutable;
+use League\Period\Period;
+
+/**
+ * This is a static analysis fixture to verify that the API signature
+ * of a period allows for pure operations. Almost all methods will seem to be
+ * redundant or trivial: that's normal, we're just verifying the
+ * transitivity of immutable type signatures.
+ *
+ * Please note that this does not guarantee that the internals of the period
+ * library are pure/safe, but just that the declared API to the outside world
+ * is seen as immutable.
+ */
+final class PeriodIsImmutable
+{
+    /** @psalm-pure */
+    public static function pureConstructor(): Period
+    {
+        return new Period(
+            new DateTimeImmutable('yesterday'),
+            new DateTimeImmutable('tomorrow'),
+        );
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     */
+    public static function pureStaticPeriodApi(): array
+    {
+        $startDate = new DateTimeImmutable('yesterday');
+        $endDate = new DateTimeImmutable('tomorrow');
+        $duration = DateInterval::createFromDateString('2 days');
+
+        $interval = [
+            'startDate' => $startDate,
+            'endDate' => $endDate,
+        ];
+
+        return [
+            Period::__set_state($interval),
+            Period::after($startDate, $duration),
+            Period::before($endDate, $duration),
+            Period::around($startDate, $duration),
+            Period::fromYear(1900),
+            Period::fromIsoYear(1900),
+            Period::fromSemester(1900),
+            Period::fromQuarter(1900),
+            Period::fromMonth(1900),
+            Period::fromIsoWeek(1900),
+            Period::fromDay(1900),
+        ];
+    }
+
+    /** @psalm-pure */
+    public static function PeriodFromDatePeriodIsPure(DatePeriod $datePeriod): Period
+    {
+        return Period::fromDatePeriod($datePeriod);
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     * @psalm-suppress DeprecatedMethod
+     */
+    public static function pureGetters(Period $a): array
+    {
+        return [
+            $a->getStartDate(),
+            $a->getEndDate(),
+            $a->getBoundaryType(),
+            $a->getTimestampInterval(),
+            $a->getDateInterval(),
+            $a->__toString(),
+            $a->toIso8601(),
+            $a->jsonSerialize(),
+            $a->format('Y-m-d'),
+            $a->isStartIncluded(),
+            $a->isStartExcluded(),
+            $a->isEndIncluded(),
+            $a->isEndExcluded(),
+        ];
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     * @psalm-suppress DeprecatedMethod
+     */
+    public static function pureComparisonRelationAndManipulation(Period $a, Period $b): array
+    {
+        return [
+            $a->durationCompare($b),
+            $a->durationEquals($b),
+            $a->durationGreaterThan($b),
+            $a->durationLessThan($b),
+            $a->isBefore($b),
+            $a->bordersOnStart($b),
+            $a->isStartedBy($b),
+            $a->isDuring($b),
+            $a->contains($b),
+            $a->equals($b),
+            $a->isEndedBy($b),
+            $a->bordersOnEnd($b),
+            $a->isAfter($b),
+            $a->abuts($b),
+            $a->overlaps($b),
+            $a->timestampIntervalDiff($b),
+            $a->dateIntervalDiff($b),
+        ];
+    }
+}

--- a/tests/static-analysis/SequenceIsImmutable.php
+++ b/tests/static-analysis/SequenceIsImmutable.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * League.Period (https://period.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace LeagueTest\Period\StaticAnalysis;
+
+use League\Period\Period;
+use League\Period\Sequence;
+
+/**
+ * This is a static analysis fixture to verify that the API signature
+ * of a period allows for pure operations. Almost all methods will seem to be
+ * redundant or trivial: that's normal, we're just verifying the
+ * transitivity of immutable type signatures.
+ *
+ * Please note that this does not guarantee that the internals of the period
+ * library are pure/safe, but just that the declared API to the outside world
+ * is seen as immutable.
+ */
+final class SequenceIsImmutable
+{
+    /** @psalm-pure */
+    public static function pureConstructor(Period $a, Period $b): Sequence
+    {
+        return new Sequence($a, $b);
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     * @psalm-suppress DeprecatedMethod
+     */
+    public static function pureGetters(Sequence $a): array
+    {
+        $a->clear();
+
+        return [
+            $a->boundaries(),
+            $a->gaps(),
+            $a->intersections(),
+            $a->unions(),
+            $a->getBoundaries(),
+            $a->getIntersections(),
+            $a->getGaps(),
+            $a->getTotalTimestampInterval(),
+            $a->toArray(),
+            $a->jsonSerialize(),
+            $a->getIterator(),
+            $a->count(),
+            $a->isEmpty(),
+
+        ];
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     * @psalm-suppress DeprecatedMethod
+     */
+    public static function pureCalculations(Sequence $a, Sequence $b): array
+    {
+        return [
+            $a->substract($b),
+            $a->subtract($b),
+        ];
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     */
+    public static function purePeriodCalculations(Sequence $a, Period $b): array
+    {
+        $a->unshift($b);
+        $a->push($b);
+
+        return [
+            $a->contains($b),
+            $a->indexOf($b),
+        ];
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     */
+    public static function purePredicateSatisfaction(Sequence $a, callable $predicate): array
+    {
+        return [
+            $a->some($predicate),
+            $a->every($predicate),
+            $a->sort($predicate),
+            $a->filter($predicate),
+            $a->sorted($predicate),
+            $a->map($predicate),
+            $a->reduce($predicate),
+        ];
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     */
+    public static function pureOffset(Sequence $a, int $offset): array
+    {
+        $a->offsetUnset($offset);
+
+        return [
+            $a->offsetExists($offset),
+            $a->offsetGet($offset),
+            $a->get($offset),
+            $a->remove($offset),
+        ];
+    }
+
+    /** @psalm-pure */
+    public static function pureOffsetSet(Sequence $a, int $offset, Period $interval): void
+    {
+        $a->offsetSet($offset, $interval);
+        $a->insert($offset, $interval);
+        $a->set($offset, $interval);
+    }
+}


### PR DESCRIPTION
This patch introduces a few improvements on the codebase:

- adds `vimeo/psalm` minimal tests (not testing sources, just declared API)
- adds `@psalm-pure` and `@psalm-immutable` to main classes, allowing usage in functionally pure (type-checked) contexts