### PR TITLE
Support DateInterval spec strings in Duration::create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `Period` will be documented in this file
 
+## 4.11.0 - TBD
+
+### Added
+
+- `Duration::create` supports DateInterval spec strings.
+
+### Fixed
+
+- None
+
+### Deprecated
+
+- None
+
+### Removed
+
+- None
+
 ## 4.10.0 - 2020-03-22
 
 ### Added

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -43,6 +43,7 @@ use League\Period\Period;
 
 Duration::create('1 DAY');                  // returns new Duration('P1D')
 Duration::create(2018);                     // returns new Duration('PT2018S')
+Duration::create('PT1H');                   // returns new Duration('PT1H')
 Duration::create(new DateInterval('PT1H')); // returns new Duration('PT1H')
 Duration::create('12:30');                  // returns new Duration('PT12M30S')  
 Duration::create(new Period('now', 'tomorrow'));

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -36,6 +36,11 @@ use const FILTER_VALIDATE_INT;
  */
 final class Duration extends DateInterval
 {
+    private const REGEXP_DATEINTERVAL_SPEC = '@^P
+        (?:(?:\d+Y)?(?:\d+M)?(?:\d+D)?)?
+        (?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?
+    $@x';
+
     private const REGEXP_MICROSECONDS_INTERVAL_SPEC = '@^(?<interval>.*)(\.|,)(?<fraction>\d{1,6})S$@';
 
     private const REGEXP_MICROSECONDS_DATE_SPEC = '@^(?<interval>.*)(\.)(?<fraction>\d{1,6})$@';
@@ -109,6 +114,11 @@ final class Duration extends DateInterval
         }
 
         $duration = (string) $duration;
+
+        if (1 === preg_match(self::REGEXP_DATEINTERVAL_SPEC, $duration)) {
+            return new self($duration);
+        }
+
         if (1 !== preg_match(self::REGEXP_CHRONO_FORMAT, $duration, $matches)) {
             $new = self::createFromDateString($duration);
             if ($new !== false) {

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -59,6 +59,10 @@ class DurationTest extends TestCase
                 'input' => Period::fromMonth(2018, 2),
                 'expected' => 'P1M',
             ],
+            'from a spec string' => [
+                'input' => 'PT1H',
+                'expect' => 'PT1H',
+            ],
             'from a week' => [
                 'input' => '1 WEEK',
                 'expected' => 'P7D',


### PR DESCRIPTION
Greetings 👋,

while testing `league/period` I noticed that I can throw almost anything at `Duration::create()` - except a DateInterval spec string, which would require me to make a check beforehand: if it's an interval spec, use `new Duration($value)`, otherwise use `Duration::create($value)`.

With the change proposed in this PR, a developer would in any case be able to "blindly" use `Duration::create()` 🥳

:octocat: