### PR TITLE
Improve Duration::create implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to `Period` will be documented in this file
 ### Added
 
 - `Duration::create` supports DateInterval spec strings.
-- `Duration::createFromTimer`
+- `Duration::createFromTimeString`
+- `Duration::createFromSeconds`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `Period` will be documented in this file
 ### Added
 
 - `Duration::create` supports DateInterval spec strings.
+- `Duration::createFromTimer`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ All notable changes to `Period` will be documented in this file
 
 ### Added
 
-- `Duration::create` supports DateInterval spec strings.
 - `Duration::createFromTimeString`
+- `Duration::createFromChronoString`
 - `Duration::createFromSeconds`
+- `Duration::create` supports DateInterval spec strings.
 
 ### Fixed
 
-- None
+- `Duration::create` when using a float will now overflow the results up to the Hour unit.
 
 ### Deprecated
 

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -51,7 +51,7 @@ Duration::create(new Period('now', 'tomorrow'));
 // returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
 ~~~
 
-### Duration::createFromTimer
+### Duration::createFromTimeString
 
 <p class="message-info">Since <code>version 4.11</code>.</p>
 
@@ -63,10 +63,25 @@ This feature was already supported via the `Duration::create` method but is now 
 ~~~php
 use League\Period\Duration;
 
-Duration::create('12:30');  // returns new Duration('PT12M30S')  
+Duration::createFromTimeString('12:30');  // returns new Duration('PT12M30S')  
 ~~~
 
 On error a `League\Period\Exception` will be thrown.
+
+### Duration::createFromSeconds
+
+<p class="message-info">Since <code>version 4.11</code>.</p>
+
+You can specifically instantiate a `Duration` instance from seconds with optional fractions.
+This feature is already supported via the `Duration::create` method but it is now accessible stand alone.
+
+#### Examples
+
+~~~php
+use League\Period\Duration;
+
+Duration::createFromSeconds('28.5');  // returns Duration::createFromDateString('28 seconds 500000 microseconds')  
+~~~
 
 ## Default constructor
 

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -29,7 +29,7 @@ Converts its single input into a `Duration` object or throws a `TypeError` other
 
 - a `League\Period\Period` object;
 - a `DateInterval` object;
-- an integer interpreted as the interval expressed in seconds.
+- a float interpreted as the interval expressed in seconds.
 - a string representing a chronometer format `+/-HH:MM::SS.FFFFFF`
 - a string following the ISO8601 interval specification parsable by `DateInterval::__construct` *since 4.11.0*
 - a string parsable by the `DateInterval::createFromDateString` method.
@@ -51,7 +51,7 @@ Duration::create(new Period('now', 'tomorrow'));
 // returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
 ~~~
 
-### Duration::createFromTimeString
+### Duration::createFromChronoString
 
 <p class="message-info">Since <code>version 4.11</code>.</p>
 
@@ -63,7 +63,25 @@ This feature was already supported via the `Duration::create` method but is now 
 ~~~php
 use League\Period\Duration;
 
-Duration::createFromTimeString('12:30');  // returns new Duration('PT12M30S')  
+Duration::createFromChronoString('12:30');  // returns new Duration('PT12M30S')  
+~~~
+
+On error a `League\Period\Exception` will be thrown.
+
+### Duration::createFromTimeString
+
+<p class="message-info">Since <code>version 4.11</code>.</p>
+
+You can specifically instantiate a `Duration` instance from a time string format in accordance with ISO8601 `+/-HH:MM::SS.FFFFFF`.
+This feature differs from `Duration::createFromChronoString` method by requiring the presence of at least the hour ans the minute unit.
+
+#### Examples
+
+~~~php
+use League\Period\Duration;
+
+Duration::createFromChronoString('12:30');     // returns new Duration('PT12H30M')
+Duration::createFromChronoString('12:30:34.8');  // returns new Duration('PT12H30M34.8S')
 ~~~
 
 On error a `League\Period\Exception` will be thrown.
@@ -73,14 +91,14 @@ On error a `League\Period\Exception` will be thrown.
 <p class="message-info">Since <code>version 4.11</code>.</p>
 
 You can specifically instantiate a `Duration` instance from seconds with optional fractions.
-This feature is already supported via the `Duration::create` method but it is now accessible stand alone.
+This feature was already supported via the `Duration::create` method but it is now accessible stand alone.
 
 #### Examples
 
 ~~~php
 use League\Period\Duration;
 
-Duration::createFromSeconds('28.5');  // returns Duration::createFromDateString('28 seconds 500000 microseconds')  
+Duration::createFromSeconds(28.5); // returns Duration::createFromDateString('28 seconds 500000 microseconds')  
 ~~~
 
 ## Default constructor

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -58,12 +58,15 @@ Duration::create(new Period('now', 'tomorrow'));
 You can specifically instantiate a `Duration` instance from a timer like string format `+/-HH:MM::SS.FFFFFF`.
 This feature was already supported via the `Duration::create` method but is now accessible stand alone.
 
+<p class="message-notice">The hour and fraction units are optional</p>
+
 #### Examples
 
 ~~~php
 use League\Period\Duration;
 
-Duration::createFromChronoString('12:30');  // returns new Duration('PT12M30S')  
+Duration::createFromChronoString('12:30');      // returns new Duration('PT12M30S')  
+Duration::createFromChronoString('12:30:34.8'); // returns new Duration('PT12H30M34.8S')
 ~~~
 
 On error a `League\Period\Exception` will be thrown.
@@ -75,13 +78,15 @@ On error a `League\Period\Exception` will be thrown.
 You can specifically instantiate a `Duration` instance from a time string format in accordance with ISO8601 `+/-HH:MM::SS.FFFFFF`.
 This feature differs from `Duration::createFromChronoString` method by requiring the presence of at least the hour ans the minute unit.
 
+<p class="message-notice">The second and fraction units are optionals</p>
+
 #### Examples
 
 ~~~php
 use League\Period\Duration;
 
-Duration::createFromChronoString('12:30');     // returns new Duration('PT12H30M')
-Duration::createFromChronoString('12:30:34.8');  // returns new Duration('PT12H30M34.8S')
+Duration::createFromTimeString('12:30');      // returns new Duration('PT12H30M')
+Duration::createFromTimeString('12:30:34.8'); // returns new Duration('PT12H30M34.8S')
 ~~~
 
 On error a `League\Period\Exception` will be thrown.

--- a/docs/4.0/duration.md
+++ b/docs/4.0/duration.md
@@ -29,9 +29,10 @@ Converts its single input into a `Duration` object or throws a `TypeError` other
 
 - a `League\Period\Period` object;
 - a `DateInterval` object;
-- a string parsable by the `DateInterval::createFromDateString` method.
-- a string representing a chronometer format `+/-HH:MM::SS.FFFFFF`
 - an integer interpreted as the interval expressed in seconds.
+- a string representing a chronometer format `+/-HH:MM::SS.FFFFFF`
+- a string following the ISO8601 interval specification parsable by `DateInterval::__construct` *since 4.11.0*
+- a string parsable by the `DateInterval::createFromDateString` method.
 
 <p class="message-warning"><strong>WARNING:</strong> When the string is not parsable by <code>DateInterval::createFromDateString</code> a <code>DateInterval</code> object representing the <code>0</code> interval is returned as described in <a href="https://bugs.php.net/bug.php?id=50020">PHP bug #50020</a>.</p>
 
@@ -49,6 +50,23 @@ Duration::create('12:30');                  // returns new Duration('PT12M30S')
 Duration::create(new Period('now', 'tomorrow'));
 // returns (new DateTime('yesterday'))->diff(new DateTime('tomorrow'))
 ~~~
+
+### Duration::createFromTimer
+
+<p class="message-info">Since <code>version 4.11</code>.</p>
+
+You can specifically instantiate a `Duration` instance from a timer like string format `+/-HH:MM::SS.FFFFFF`.
+This feature was already supported via the `Duration::create` method but is now accessible stand alone.
+
+#### Examples
+
+~~~php
+use League\Period\Duration;
+
+Duration::create('12:30');  // returns new Duration('PT12M30S')  
+~~~
+
+On error a `League\Period\Exception` will be thrown.
 
 ## Default constructor
 

--- a/phpstan.src.neon
+++ b/phpstan.src.neon
@@ -11,13 +11,7 @@ parameters:
           path: src/Duration.php
         - message: '#^Variable property access on (.*)?.#'
           path: src/Duration.php
-        - message: '#Strict comparison using !== between League\\Period\\Duration and false will always evaluate to true.#'
-          path: src/Duration.php
-        - message: '#Strict comparison using === between false and League\\Period\\Duration will always evaluate to false.#'
-          path: src/Duration.php
-        - message: '#PHPDoc tag \@return with type static\(League\\Period\\Duration\)\|false is not subtype of native type League\\Period\\Duration.#'
-          path: src/Duration.php
-        - message: '#Unreachable statement - code above always terminates.#'
+        - message: '#Return type \(League\\Period\\Duration\|false\) of method League\\Period\\Duration::createFromDateString\(\) should be covariant with return type \(DateInterval\) of method DateInterval::createFromDateString\(\)#'
           path: src/Duration.php
         - message: '#Parameter \#1 ...\$intervals of class League\\Period\\Sequence constructor expects array<int\, League\\Period\\Period>, array<League\\Period\\Period\|null> given.#'
           path: src/Period.php

--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -6,8 +6,6 @@ parameters:
     checkGenericClassInNonGenericObjectType: false
     checkMissingIterableValueType: false
     ignoreErrors:
-        - message: '#Strict comparison using !== between false and League\\Period\\Duration will always evaluate to true.#'
-          path: tests/DurationTest.php
         - message: '#Variable method call on League\\Period\\Period.#'
           path: tests/PeriodTest.php
         - message: '#Variable method call on League\\Period\\Period.#'

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -52,20 +52,16 @@ final class Duration extends DateInterval
     private const REGEXP_MICROSECONDS_DATE_SPEC = '@^(?<interval>.*)(\.)(?<fraction>\d{1,6})$@';
 
     private const REGEXP_CHRONO_FORMAT = '@^
-        (?<sign>\+|-)?
-        (
-            (
-                (?<hour>\d+):)?
-                (?<minute>\d+):
-            )?
-            ((?<second>\d+)(\.(?<fraction>\d{1,6}))?
-        )
+        (?<sign>\+|-)?                  # optional sign
+        ((?<hour>\d+):)?                # optional hour
+        ((?<minute>\d+):)(?<second>\d+) # required minute and second
+        (\.(?<fraction>\d{1,6}))?       # optional fraction
     $@x';
 
     private const REGEXP_TIME_FORMAT = '@^
-        (?<sign>\+|-)?
-        (?<hour>\d+)(:(?<minute>\d+))
-        (:(?<second>\d+)(\.(?<fraction>\d{1,6}))?)?
+        (?<sign>\+|-)?                               # optional sign
+        (?<hour>\d+)(:(?<minute>\d+))                # required hour and minute
+        (:(?<second>\d+)(\.(?<fraction>\d{1,6}))?)?  # optional second and fraction
     $@x';
 
     /**
@@ -192,18 +188,9 @@ final class Duration extends DateInterval
             throw new Exception(sprintf('Unknown or bad format (%s)', $duration));
         }
 
-        $units['hour'] = $units['hour'] ?? '0';
         if ('' === $units['hour']) {
             $units['hour'] = '0';
         }
-
-        $units['minute'] = $units['minute'] ?? '0';
-        if ('' === $units['minute']) {
-            $units['minute'] = '0';
-        }
-
-        /** @var array{hour:string, minute:string, second:string, fraction:string, sign:string} $units */
-        $units = $units + ['second' => '0', 'fraction' => '0', 'sign' => '+'];
 
         return self::createFromTimeUnits($units);
     }
@@ -219,19 +206,18 @@ final class Duration extends DateInterval
             throw new Exception(sprintf('Unknown or bad format (%s)', $duration));
         }
 
-        /** @var array{hour:string, minute:string, second:string, fraction:string, sign:string} $units */
-        $units = $units + ['minute' => '0', 'second' => '0', 'fraction' => '0', 'sign' => '+'];
-
         return self::createFromTimeUnits($units);
     }
 
     /**
      * Creates an instance from DateInterval units.
      *
-     * @param array{hour:string, minute:string, second:string, fraction:string, sign:string} $units
+     * @param array<string,string> $units
      */
     private static function createFromTimeUnits(array $units): self
     {
+        $units = $units + ['hour' => '0', 'minute' => '0', 'second' => '0', 'fraction' => '0', 'sign' => '+'];
+
         $units['fraction'] = str_pad($units['fraction'] ?? '000000', 6, '0');
 
         $expression = $units['hour'].' hours '.

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -18,6 +18,8 @@ use League\Period\Duration;
 use League\Period\Exception;
 use League\Period\Period;
 use PHPUnit\Framework\Error\Warning;
+use function version_compare;
+use const PHP_VERSION;
 
 class DurationTest extends TestCase
 {
@@ -120,9 +122,22 @@ class DurationTest extends TestCase
      */
     public function testDurationCreateFromDateStringFails(string $input): void
     {
+        if (!$this->isBugFixedcreateFromDateString()) {
+            self::assertEquals(new Duration('PT0S'), Duration::createFromDateString($input));
+
+            return;
+        }
+
         self::expectException(Warning::class);
 
         self::assertFalse(Duration::createFromDateString($input));
+    }
+
+    private function isBugFixedcreateFromDateString(): bool
+    {
+        return version_compare(PHP_VERSION, '7.3.4', '>=') ||
+            (version_compare(PHP_VERSION, '7.2.17', '>=') &&
+                version_compare(PHP_VERSION, '7.3', '<'));
     }
 
     public function getDurationCreateFromDateStringFailsProvider(): iterable

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -157,12 +157,31 @@ class DurationTest extends TestCase
         self::assertSame(0.023658, $duration->f);
     }
 
+    public function testCreateFromTimeStringFails(): void
+    {
+        self::expectException(Exception::class);
+
+        Duration::createFromTimeString('foobar');
+    }
+
     /**
      * @dataProvider fromChronoProvider
      */
-    public function testCreateFromTimeString(string $chronometer, string $expected, int $revert): void
+    public function testCreateFromTimeStringSucceeds(string $chronometer, string $expected, int $revert): void
+    {
+        $duration = Duration::createFromTimeString($chronometer);
+
+        self::assertSame($expected, (string) $duration);
+        self::assertSame($revert, $duration->invert);
+    }
+
+    /**
+     * @dataProvider fromChronoProvider
+     */
+    public function testCreate(string $chronometer, string $expected, int $revert): void
     {
         $duration = Duration::create($chronometer);
+
         self::assertSame($expected, (string) $duration);
         self::assertSame($revert, $duration->invert);
     }

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -161,15 +161,64 @@ class DurationTest extends TestCase
     {
         self::expectException(Exception::class);
 
-        Duration::createFromTimeString('foobar');
+        Duration::createFromTimeString('123');
+    }
+
+    /**
+     * @dataProvider fromTimeStringProvider
+     */
+    public function testCreateFromTimeStringSucceeds(string $chronometer, string $expected, int $revert): void
+    {
+        $duration = Duration::createFromTimeString($chronometer);
+
+        self::assertSame($expected, (string) $duration);
+        self::assertSame($revert, $duration->invert);
+    }
+
+    public function fromTimeStringProvider(): iterable
+    {
+        return [
+            'hour and minute' => [
+                'chronometer' => '1:2',
+                'expected' => 'PT1H2M',
+                'invert' => 0,
+            ],
+            'hour, minute, seconds' => [
+                'chronometer' => '1:2:3',
+                'expected' => 'PT1H2M3S',
+                'invert' => 0,
+            ],
+            'handling 0 prefix' => [
+                'chronometer' => '00001:00002:000003.0004',
+                'expected' => 'PT1H2M3.0004S',
+                'invert' => 0,
+            ],
+            'negative chrono' => [
+                'chronometer' => '-12:28',
+                'expected' => 'PT12H28M',
+                'invert' => 1,
+            ],
+            'negative chrono with seconds' => [
+                'chronometer' => '-00:00:28.5',
+                'expected' => 'PT28.5S',
+                'invert' => 1,
+            ],
+        ];
+    }
+
+    public function testCreateFromChronoStringFails(): void
+    {
+        self::expectException(Exception::class);
+
+        Duration::createFromChronoString('foobar');
     }
 
     /**
      * @dataProvider fromChronoProvider
      */
-    public function testCreateFromTimeStringSucceeds(string $chronometer, string $expected, int $revert): void
+    public function testCreateFromChronoStringSucceeds(string $chronometer, string $expected, int $revert): void
     {
-        $duration = Duration::createFromTimeString($chronometer);
+        $duration = Duration::createFromChronoString($chronometer);
 
         self::assertSame($expected, (string) $duration);
         self::assertSame($revert, $duration->invert);
@@ -231,6 +280,7 @@ class DurationTest extends TestCase
     {
         $duration = new Duration($input);
         self::assertSame($expected, (string) $duration->withoutCarryOver($reference_date));
+        self::assertSame($expected, (string) $duration->adjustedTo($reference_date));
     }
 
     public function withoutCarryOverDataProvider(): iterable

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -120,7 +120,7 @@ class DurationTest extends TestCase
      */
     public function testDurationCreateFromDateStringFails(string $input): void
     {
-        self::expectWarning();
+        self::expectException(Warning::class);
 
         self::assertFalse(Duration::createFromDateString($input));
     }

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -206,11 +206,22 @@ class DurationTest extends TestCase
         ];
     }
 
-    public function testCreateFromChronoStringFails(): void
+    /**
+     * @dataProvider fromChronoFailsProvider
+     */
+    public function testCreateFromChronoStringFails(string $input): void
     {
         self::expectException(Exception::class);
 
-        Duration::createFromChronoString('foobar');
+        Duration::createFromChronoString($input);
+    }
+
+    public function fromChronoFailsProvider(): iterable
+    {
+        return [
+            'invalid string' => ['foobar'],
+            'float like string' => ['-28.5'],
+        ];
     }
 
     /**
@@ -238,11 +249,6 @@ class DurationTest extends TestCase
     public function fromChronoProvider(): iterable
     {
         return [
-            'seconds' => [
-                'chronometer' => '1',
-                'expected' => 'PT1S',
-                'invert' => 0,
-            ],
             'minute and seconds' => [
                 'chronometer' => '1:2',
                 'expected' => 'PT1M2S',
@@ -261,11 +267,6 @@ class DurationTest extends TestCase
             'negative chrono' => [
                 'chronometer' => '-12:28.5',
                 'expected' => 'PT12M28.5S',
-                'invert' => 1,
-            ],
-            'negative chrono with seconds' => [
-                'chronometer' => '-28.5',
-                'expected' => 'PT28.5S',
                 'invert' => 1,
             ],
         ];


### PR DESCRIPTION
This PR 

- improve `Duration::create` implementation with support to the interval specification string introduces via #104 
- exposes the `Duration::createFromTimeString` named constructor
- exposes the `Duration::createFromSeconds` named constructor

@jeromegamez could you review the modifications and see if they are valid.
