### PR TITLE
Fix phpstan errors

### DIFF
--- a/phpstan.src.neon
+++ b/phpstan.src.neon
@@ -13,7 +13,7 @@ parameters:
           path: src/Duration.php
         - message: '#Return type \(League\\Period\\Duration\|false\) of method League\\Period\\Duration::createFromDateString\(\) should be covariant with return type \(DateInterval\) of method DateInterval::createFromDateString\(\)#'
           path: src/Duration.php
-        - message: '#Parameter \#1 ...\$intervals of class League\\Period\\Sequence constructor expects array<int\, League\\Period\\Period>, array<League\\Period\\Period\|null> given.#'
+        - message: '#Parameter \#1 ...\$intervals of class League\\Period\\Sequence constructor expects League\\Period\\Period, League\\Period\\Period\|null given.#'
           path: src/Period.php
         - message: '#Method League\\Period\\Datepoint::createFromFormat\(\) should return static\(League\\Period\\Datepoint\)\|false but returns League\\Period\\Datepoint.#'
           path: src/Datepoint.php


### PR DESCRIPTION
Hi there,

with the release of phpstan `0.12.28`, the error message for variadic checks seems to have changed. Therefore the error message was not ignored any more.
The [last green master build](https://travis-ci.org/github/thephpleague/period/jobs/691180043) used phpstan `0.12.25`, whereas the [next build](https://travis-ci.org/github/thephpleague/period/jobs/723954875) from the very next commit (three months later) used phpstan `0.12.45` failed.

This PR ignores the right error message, and the build should be green again.