### PR TITLE
Adding full support of ISO8601 notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `Period` will be documented in this file
 
+## [Next] - TBD
+
+### Added
+
+- `DatePoint::fromFormat` to instantiate from a date format and its related string. 
+
+### Fixed
+
+- `Period::fromIso8601` now supports truncated date and duration in the interval string.
+
+### Deprecated
+
+- None
+
+### Removed
+
+- None
+
 ## [5.0.0] - 2022-02-22
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "phpcs": "php-cs-fixer fix --dry-run --diff -vvv --allow-risky=yes --ansi",
         "phpcs:fix": "php-cs-fixer fix -vvv --allow-risky=yes --ansi",
         "phpstan": "phpstan analyse -c phpstan.neon --ansi --memory-limit 192M",
-        "phpunit": "phpunit --coverage-text",
+        "phpunit": "XDEBUG_MODE=coverage phpunit --coverage-text",
         "test": [
             "@phpunit",
             "@phpstan",

--- a/docs/5.0/period/index.md
+++ b/docs/5.0/period/index.md
@@ -159,6 +159,29 @@ $day = Period::fromIso8601('Y-m-d', '2012-01-03/2012-02-03');
 echo $day->toIso80000('Y-m-d H:i:s'), //return [2012-01-03 21:38:22, 2012-02-03 21:38:22)
 ~~~
 
+<p class="message-notice">New in <code>version 5.1</code> extended support for ISO8601 notation is added.</p>
+
+The previous example can be rewritten as follow:
+
+~~~php
+$day = Period::fromIso8601('Y-m-d', '2012-01-03/02-03'); // the end value is extended (the year is skipped)
+echo $day->toIso80000('Y-m-d H:i:s'), //return [2012-01-03 21:38:22, 2012-02-03 21:38:22)
+~~~
+
+or
+
+~~~php
+$day = Period::fromIso8601('Y-m-d', '2012-01-03/P1M'); // the end value is a duration
+echo $day->toIso80000('Y-m-d H:i:s'), //return [2012-01-03 21:38:22, 2012-02-03 21:38:22)
+~~~
+
+or
+
+~~~php
+$day = Period::fromIso8601('Y-m-d', 'P1M/2012-01-03'); // the start value is a duration
+echo $day->toIso80000('Y-m-d H:i:s'), //return [2012-01-03 21:38:22, 2012-02-03 21:38:22)
+~~~
+
 #### Using ISO 80000 notation
 
 The `$notation` should follow the `{lowerbound}{startDate},{endDate}{upperbound}` where `,` serves as delimiter. 

--- a/src/DatePoint.php
+++ b/src/DatePoint.php
@@ -65,6 +65,16 @@ final class DatePoint
         return new self((new DateTimeImmutable())->setTimestamp($timestamp));
     }
 
+    public static function fromFormat(string $format, string $dateString): self
+    {
+        $date = DateTimeImmutable::createFromFormat($format, $dateString);
+        if (false === $date) {
+            throw InvalidInterval::dueToInvalidDateFormat($format, $dateString);
+        }
+
+        return new self($date);
+    }
+
     /**************************************************
      * Relation methods
      **************************************************/

--- a/src/InvalidInterval.php
+++ b/src/InvalidInterval.php
@@ -31,6 +31,11 @@ final class InvalidInterval extends InvalidArgumentException implements Interval
         return new self('The date notation `'.$date.'` is incompatible with the date format `'.$format.'`.');
     }
 
+    public static function dueToInvalidRelativeDateFormat(string $endDate, string $startDate): self
+    {
+        return new self('The end date notation `'.$endDate.'` is incompatible with the start date notation `'.$startDate.'`.');
+    }
+
     public static function dueToInvalidDatePeriod(): self
     {
         return new self('The '.DatePeriod::class.' should contain an end date to instantiate a '.Period::class.' class.');

--- a/src/PeriodFactoryTest.php
+++ b/src/PeriodFactoryTest.php
@@ -474,6 +474,34 @@ final class PeriodFactoryTest extends PeriodTest
                 'outputFormat'=> 'Y-n-d',
                 'expected' => '2021-3-25/2021-3-26',
             ],
+            'same input/output format extended' => [
+                'inputFormat' => 'Y-m-d',
+                'notation' => '2021-03-25/26',
+                'bounds' => Bounds::IncludeAll,
+                'outputFormat'=> 'Y-m-d',
+                'expected' => '2021-03-25/2021-03-26',
+            ],
+            'different input/output format extended' => [
+                'inputFormat' => 'Y-m-d',
+                'notation' => '2021-03-25/03-26',
+                'bounds' => Bounds::ExcludeAll,
+                'outputFormat'=> 'Y-n-d',
+                'expected' => '2021-3-25/2021-3-26',
+            ],
+            'different input/output format with interval duration after start' => [
+                'inputFormat' => 'Y-m-d',
+                'notation' => '2021-03-25/P1D',
+                'bounds' => Bounds::ExcludeAll,
+                'outputFormat'=> 'Y-n-d',
+                'expected' => '2021-3-25/2021-3-26',
+            ],
+            'different input/output format with interval duration before end' => [
+                'inputFormat' => 'Y-m-d',
+                'notation' => 'P1D/2021-03-26',
+                'bounds' => Bounds::ExcludeAll,
+                'outputFormat'=> 'Y-n-d',
+                'expected' => '2021-3-25/2021-3-26',
+            ],
         ];
     }
 
@@ -498,6 +526,9 @@ final class PeriodFactoryTest extends PeriodTest
             'too many separator' => ['2021-01-02/2021-/01-03', 'Y-m-d', Bounds::IncludeAll],
             'missing dates' => ['2021-01-02/', 'Y-m-d', Bounds::IncludeAll],
             'wrong format' => ['2021-01-02/2021-01-03', 'Ymd', Bounds::IncludeAll],
+            'invalid extended format delimiters are different' => ['2021-01-02/01:03', 'Ymd', Bounds::IncludeAll],
+            'invalid extended format start date is shorter than end date' => ['01/2021-01-02', 'Ymd', Bounds::IncludeAll],
+            'invalid date with wrong period' => ['PMD/2021-01-02', 'Ymd', Bounds::IncludeAll],
         ];
     }
 }


### PR DESCRIPTION
This PR adds support for missing `ISO8601` notation to `Period::fromIso8601`

the following representation are added:

- `<start>/<end>` where end is truncated (ie `2022-05-23/24` which is the equivalent of `2022-05-23/2022-05-24`
- `<start>/<duration>` where the duration represents the duration after start (ie `2022-05-23/P1D` )
- `<duration>/<end>` where the duration represents the duration before end (ie `P1D/2022-05-24` )

